### PR TITLE
Add Test Skip and minor corrections

### DIFF
--- a/test_pool/iic/operating_system/test_os_i002.c
+++ b/test_pool/iic/operating_system/test_os_i002.c
@@ -178,11 +178,11 @@ payload()
   /* Checkpoint 9: Read the stopei register to verify that the highest priority external
           interrupt identity is reported.
   */
-  val_print(ACS_PRINT_INFO, "\n       Read and check CSR_STOPI has expected value", 0);
+  val_print(ACS_PRINT_INFO, "\n       Read and check CSR_STOPEI has expected value", 0);
   val = csr_read(CSR_STOPEI);
   val_print(ACS_PRINT_INFO, "\n         CSR_STOPEI: 0x%lx", val);
   if (val != (TEST_EXT_IRQ_ID | (TEST_EXT_IRQ_ID << IMSIC_TOPEI_ID_SHIFT))) {
-    val_print(ACS_PRINT_ERR, "\n       Unexpected CSR_STOPI value: 0x%lx", val);
+    val_print(ACS_PRINT_ERR, "\n       Unexpected CSR_STOPEI value: 0x%lx", val);
     val_set_status(index, RESULT_FAIL(TEST_NUM, 5));
     return;
   }

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -703,8 +703,9 @@ ShellAppMain (
 print_test_status:
   val_print(ACS_PRINT_TEST, "\n     -------------------------------------------------------", 0);
   val_print(ACS_PRINT_TEST, "\n     Total Tests run  = %4d", g_bsa_tests_total);
-  val_print(ACS_PRINT_TEST, "\n     Tests Passed  = %4d", g_bsa_tests_pass);
-  val_print(ACS_PRINT_TEST, "\n     Tests Failed = %4d\n", g_bsa_tests_fail);
+  val_print(ACS_PRINT_TEST, "\n     Tests Passed     = %4d", g_bsa_tests_pass);
+  val_print(ACS_PRINT_TEST, "\n     Tests Failed     = %4d", g_bsa_tests_fail);
+  val_print(ACS_PRINT_TEST, "\n     Tests Skipped    = %4d\n", g_bsa_tests_total - g_bsa_tests_pass - g_bsa_tests_fail);
   val_print(ACS_PRINT_TEST, "\n     -------------------------------------------------------", 0);
 
   freeBsaAcsMem();


### PR DESCRIPTION
This PR adds Test Skipped variable as discussed in Issue #3 and also corrects the name of csr stopi to stopei,

![image](https://github.com/user-attachments/assets/c5639cf3-8beb-4c47-aa08-64a6e2f1908a)
