### PR TITLE
Add IOMMU & PCIe test support

### DIFF
--- a/patches/0001-Add-EFI_ACPI_6_5_RIMT_PLATFORM_DEVICE_BINDING_STR.patch
+++ b/patches/0001-Add-EFI_ACPI_6_5_RIMT_PLATFORM_DEVICE_BINDING_STR.patch
@@ -1,0 +1,34 @@
+From a38900e9c0b3ecbe0708010755ed830b5d09295b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E9=83=91=E5=9F=B900354317?= <zheng.pei@zte.com.cn>
+Date: Mon, 16 Mar 2026 14:38:01 +0800
+Subject: [PATCH] 1. Add EFI_ACPI_6_5_RIMT_PLATFORM_DEVICE_BINDING_STRUCTURE
+ define
+
+---
+ MdePkg/Include/IndustryStandard/Acpi65.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/MdePkg/Include/IndustryStandard/Acpi65.h b/MdePkg/Include/IndustryStandard/Acpi65.h
+index 496c8048ec..06dddf40bd 100644
+--- a/MdePkg/Include/IndustryStandard/Acpi65.h
++++ b/MdePkg/Include/IndustryStandard/Acpi65.h
+@@ -3150,6 +3150,16 @@ typedef struct {
+   //EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE    IdMappings[];
+ } EFI_ACPI_6_5_RIMT_PCIE_ROOT_COMPLEX_DEVICE_BINDING_STRUCTURE;
+ 
++///
++/// RIMT Platform Device Binding Structure
++///
++typedef struct {
++  EFI_ACPI_6_5_RIMT_DEVICE_HEADER Header;
++  UINT16      IdMappingOffset;
++  UINT16      IdMappingNumber;
++  //EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE    IdMappings[];
++} EFI_ACPI_6_5_RIMT_PLATFORM_DEVICE_BINDING_STRUCTURE;
++
+ typedef struct {
+   UINT32      SourceIdBase;
+   UINT32      IdNumber;
+-- 
+2.27.0
+

--- a/platform/pal_uefi_acpi/BsaPalLib.inf
+++ b/platform/pal_uefi_acpi/BsaPalLib.inf
@@ -37,9 +37,9 @@
   src/pal_mng.c
   src/pal_pcie.c
   # src/pal_iovirt.c
-  # src/pal_pcie_enumeration.c
+  src/pal_pcie_enumeration.c
   # src/pal_peripherals.c
-  # src/pal_exerciser.c
+  src/pal_exerciser.c
   # src/pal_smmu.c
 
 [Packages]

--- a/platform/pal_uefi_acpi/include/pal_uefi.h
+++ b/platform/pal_uefi_acpi/include/pal_uefi.h
@@ -122,17 +122,34 @@ typedef struct {
   UINT32  num_of_iommu;
 } IOMMU_INFO_HDR;
 
+/**
+  @brief  ID Mapping Structure
+**/
+typedef struct {
+  UINT32  sourceid_base;
+  UINT32  numids;
+  UINT32  destid_base;
+  UINT32  destiommu_offset;
+} ID_MAPPTING_TABLE;
+
 typedef struct {
   UINT32  iommu_num;  ///< info entry index
   UINT8   type;
   UINT16  id;
 
   /* IOMMU device specific */
+  UINT32  iommu_offset;
   UINT64  hardware_id;
   UINT64  base_address;
   UINT32  flags;
+  UINT16  pcie_seg;
+  UINT16  pcie_bdf;
 
-  /* PCIe Root Complex specific */
+  /* PCIe Root Complex or PLatform device specific */
+  UINT16  idmap_offset;
+  UINT16  idmap_num;
+  UINT16  pcie_rc_seg;
+  ID_MAPPTING_TABLE id_mapping_table[];
 } IOMMU_INFO_ENTRY;
 
 typedef struct {

--- a/platform/pal_uefi_acpi/src/pal_acpi.c
+++ b/platform/pal_uefi_acpi/src/pal_acpi.c
@@ -371,3 +371,19 @@ pal_get_fadt_ptr (
 
   return 0;
 }
+
+/**
+  @brief   Iterate through the tables pointed by XSDT and return DSDT Table address
+  @param   None
+  @return  64-bit address of DSDT table
+  @retval  0:  DSDT table could not be found
+**/
+UINT64
+pal_get_dsdt_ptr (
+  VOID
+  )
+{
+  EFI_ACPI_6_5_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt;
+  Fadt = (EFI_ACPI_6_5_FIXED_ACPI_DESCRIPTION_TABLE *)pal_get_fadt_ptr ();
+  return (UINT64)(Fadt->Dsdt);
+}

--- a/platform/pal_uefi_acpi/src/pal_iommu.c
+++ b/platform/pal_uefi_acpi/src/pal_iommu.c
@@ -27,9 +27,14 @@ pal_iommu_create_info_table(IOMMU_INFO_TABLE *IommuTable)
   UINT32                            TableLength;
   EFI_ACPI_6_5_RIMT_DEVICE_HEADER   *Entry;
   EFI_ACPI_6_5_RIMT_IOMMU_DEVICE_STRUCTURE  *IommuEntry;
+  EFI_ACPI_6_5_RIMT_PCIE_ROOT_COMPLEX_DEVICE_BINDING_STRUCTURE  *PCIeRCEntry;
+  EFI_ACPI_6_5_RIMT_PLATFORM_DEVICE_BINDING_STRUCTURE *PlatformEntry;
+  EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE *IdMapEntry;
   IOMMU_INFO_ENTRY                  *Ptr = NULL;
+  ID_MAPPTING_TABLE                 *IdMapPtr = NULL;
 
   UINT32                            Length = 0;
+  UINT32                            NodeLength = 0;
 
   bsa_print(ACS_PRINT_INFO, L" Creating IOMMU INFO\n");
 
@@ -63,10 +68,52 @@ pal_iommu_create_info_table(IOMMU_INFO_TABLE *IommuTable)
 
     if (Entry->Type == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
       IommuEntry = (EFI_ACPI_6_5_RIMT_IOMMU_DEVICE_STRUCTURE *) Entry;
+      Ptr->iommu_offset = Length;
       Ptr->hardware_id  = IommuEntry->HardwareID;
       Ptr->base_address = IommuEntry->BaseAddress;
       Ptr->flags        = IommuEntry->Flags;
+      Ptr->pcie_seg        = IommuEntry->PcieSegmentNumber;
+      Ptr->pcie_bdf        = IommuEntry->PcieBDF;
       bsa_print(ACS_PRINT_INFO, L"    IOMMU base address 0x%lx\n", Ptr->base_address);
+    } else if (Entry->Type == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_PCIE_ROOT_COMPLEX) {
+      PCIeRCEntry = (EFI_ACPI_6_5_RIMT_PCIE_ROOT_COMPLEX_DEVICE_BINDING_STRUCTURE *) Entry;
+      Ptr->pcie_rc_seg = PCIeRCEntry->PcieSegmentNumber;
+      Ptr->idmap_offset = PCIeRCEntry->IdMappingOffset;
+      // Ptr->idmap_num = PCIeRCEntry->IdMappingNumber;
+      Ptr->idmap_num = 0;
+      IdMapPtr = Ptr->id_mapping_table;
+      NodeLength = Ptr->idmap_offset;
+      IdMapEntry = (EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE *)((UINT8 *)PCIeRCEntry + PCIeRCEntry->IdMappingOffset);
+      do {
+        IdMapPtr->sourceid_base = IdMapEntry->SourceIdBase;
+        IdMapPtr->numids = IdMapEntry->IdNumber;
+        IdMapPtr->destid_base = IdMapEntry->DestDeviceIdBase;
+        IdMapPtr->destiommu_offset = IdMapEntry->DestIommuOffset;
+        bsa_print(ACS_PRINT_INFO, L"    IOMMU sourceid base 0x%x\n", IdMapPtr->sourceid_base );
+        bsa_print(ACS_PRINT_INFO, L"    IOMMU numids 0x%x\n", IdMapPtr->numids );
+        bsa_print(ACS_PRINT_INFO, L"    IOMMU destid_base 0x%x\n", IdMapPtr->destid_base );
+        bsa_print(ACS_PRINT_INFO, L"    IOMMU destiommu_offset 0x%x\n", IdMapPtr->destiommu_offset );
+        NodeLength += sizeof(EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE);
+        IdMapPtr++;
+        Ptr->idmap_num++;
+      } while(NodeLength < Entry->Length);
+    } else if (Entry->Type == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_Platform_DEVICE) {
+      PlatformEntry = (EFI_ACPI_6_5_RIMT_PLATFORM_DEVICE_BINDING_STRUCTURE *) Entry;
+      Ptr->idmap_offset = PlatformEntry->IdMappingOffset;
+      // Ptr->idmap_num = PlatformEntry->IdMappingNumber;
+      Ptr->idmap_num = 0;
+      IdMapPtr = Ptr->id_mapping_table;
+      NodeLength = Ptr->idmap_offset;
+      IdMapEntry = (EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE *)((UINT8 *)PlatformEntry + PlatformEntry->IdMappingOffset);
+      do {
+        IdMapPtr->sourceid_base = IdMapEntry->SourceIdBase;
+        IdMapPtr->numids = IdMapEntry->IdNumber;
+        IdMapPtr->destid_base = IdMapEntry->DestDeviceIdBase;
+        IdMapPtr->destiommu_offset = IdMapEntry->DestIommuOffset;
+        NodeLength += sizeof(EFI_ACPI_6_5_RIMT_ID_MAPPING_STRUCTURE);
+        IdMapPtr++;
+        Ptr->idmap_num++;
+      } while(NodeLength < Entry->Length);
     }
 
     Length += Entry->Length;

--- a/test_pool/iommu/operating_system/test_os_iom001.c
+++ b/test_pool/iommu/operating_system/test_os_iom001.c
@@ -26,17 +26,11 @@ payload()
   uint32_t index;
   uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
   uint32_t iommu_num = val_iommu_get_num();
-  uint64_t base_addr, reg_cap;
+  uint64_t reg_cap;
 
   for (index = 0; index < iommu_num; index++) {
     if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
-      base_addr = val_iommu_get_info (index, IOMMU_INFO_BASE_ADDRESS);
-
-      /* Map the IOMMU memory-mapped register region */
-      val_print(ACS_PRINT_INFO, "\n       IOMMU base: 0x%lx", base_addr);
-      val_memory_map_add_mmio(base_addr, 0x1000);
-
-      reg_cap = val_mmio_read64(base_addr + RISCV_IOMMU_REG_CAP);
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
       val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
       if ((reg_cap & RISCV_IOMMU_CAP_VERSION_MSK) != RISCV_IOMMU_CAP_VERSION_1_0) {
         val_print(ACS_PRINT_ERR, "\n       Incorrect IOMMU version - 0x%x", (reg_cap & RISCV_IOMMU_CAP_VERSION_MSK));

--- a/test_pool/iommu/operating_system/test_os_iom002.c
+++ b/test_pool/iommu/operating_system/test_os_iom002.c
@@ -1,0 +1,80 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 2)
+#define TEST_RULE  "ME_IOM_020_010"
+#define TEST_DESC  "Verify RCiEP and RP exit governing IOMMU               "
+
+/**
+ * @brief For each application processor hart:
+ * 1. Use PCIe discovery to locate all RCiEPs and PCIe RPs.
+ * 2. Locate the ACPI RIMT tables of all IOMMUs.
+ * 3. For each RCiEP, verify that there is a governing IOMMU.
+ * 4. For each RP, verify that there is a governing IOMMU.
+ */
+static
+void
+payload()
+{
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t bdf = 0;
+  uint32_t dp_type;
+  uint32_t tbl_index = 0;
+  uint8_t ret = 0xff;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t iommu_index = 0;
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  while (tbl_index < bdf_tbl_ptr->num_entries) {
+
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RCiEP || dp_type == RP) {
+        val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+        val_print(ACS_PRINT_DEBUG, "\n       DP TYPE - %d", dp_type);
+        ret = val_iommu_check_governing_iommu (bdf, &iommu_index);
+        if (ret == 0) {
+          val_print(ACS_PRINT_ERR, "\n       IOMMU is not governing for bdf: 0x%x", bdf);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+      }
+  }
+
+  if (ret == 1) {
+    val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  } else {
+    val_print(ACS_PRINT_ERR, "\n       SKIP: NO RCiEP AND RP DEVICE", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+
+  return;
+}
+
+uint32_t
+os_iom002_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom003.c
+++ b/test_pool/iommu/operating_system/test_os_iom003.c
@@ -1,0 +1,131 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 3)
+#define TEST_RULE  "ME_IOM_030_010"
+#define TEST_DESC  "Check IOMMUs which governing PCIe root ports capabilities and ddtp register               "
+
+#define RISCV_IOMMU_REG_CAP             0x0
+#define RISCV_IOMMU_CAP_MSIFLAT_MSK     (1 << 22)
+#define MSIFLAT_ENABLE                  (1 << 22)
+
+#define RISCV_IOMMU_REG_DDTP            0x10
+#define RISCV_IOMMU_DDTP_LVL_MSK        0xf
+#define RISCV_IOMMU_DDTP_LVL_2          3
+#define RISCV_IOMMU_DDTP_LVL_3          4
+
+static
+uint8_t
+check_iommu_cap_ddtp_reg (uint32_t index)
+{
+  uint64_t reg_cap, reg_ddtp;
+  uint32_t iommu_num = val_iommu_get_num();
+
+  if (index >= iommu_num) {
+    val_print(ACS_PRINT_ERR, "\n       IOMMU index error - 0x%x", index);
+    return 0;
+  }
+
+  if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+    reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+    reg_ddtp = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_DDTP, 2);
+
+    val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+    val_print(ACS_PRINT_INFO, "\n       IOMMU reg_ddtp - 0x%lx", reg_ddtp);
+    val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap ddtp level- 0x%x", reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK);
+    if ((reg_cap & RISCV_IOMMU_CAP_MSIFLAT_MSK) != MSIFLAT_ENABLE) {
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap msi_flat- 0", 0);
+        if (((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) == RISCV_IOMMU_DDTP_LVL_2) || \
+            ((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) == RISCV_IOMMU_DDTP_LVL_3)) {
+            return 1;
+        }
+    } else {
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap msi_flat- 1", 0);
+        if (((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) == RISCV_IOMMU_DDTP_LVL_3)) {
+            return 1;
+        }
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * @brief For each application processor hart:
+ * 1. Locate all IOMMUs governing PCIe root ports.
+ * 2. For each located IOMMU:
+ *   a. if capabilities.MSI_FLAT is 0, then the ddtp must support at least 2 level DDT.
+ *   b. if capabilities.MSI_FLAT is 1, then the ddtp must support 3 level DDT.
+ */
+static
+void
+payload()
+{
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t bdf = 0;
+  uint32_t dp_type;
+  uint32_t tbl_index = 0;
+  uint8_t ret = 0xff;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t iommu_index = 0;
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  while (tbl_index < bdf_tbl_ptr->num_entries) {
+
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RP) {
+        ret = val_iommu_check_governing_iommu (bdf, &iommu_index);
+        if (ret == 0) {
+          val_print(ACS_PRINT_ERR, "\n       IOMMU is not governing for bdf: 0x%x", bdf);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        } else {
+          val_print(ACS_PRINT_INFO, "\n       IOMMU is governing for bdf: 0x%x", bdf);
+          val_print(ACS_PRINT_INFO, "\n       Governing IOMMU index: 0x%x", iommu_index);
+          ret = check_iommu_cap_ddtp_reg (iommu_index);
+          if (ret == 0) {
+            val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+            return;
+          }
+        }
+      }
+  }
+
+  if (ret == 1) {
+    val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  } else {
+    val_print(ACS_PRINT_ERR, "\n       SKIP: NO RP GOVERNING IOMMU NODE", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+  return;
+}
+
+uint32_t
+os_iom003_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom004.c
+++ b/test_pool/iommu/operating_system/test_os_iom004.c
@@ -1,0 +1,192 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 4)
+#define TEST_RULE  "ME_IOM_040_010"
+#define TEST_DESC  "Check IOMMUs which governing platform device ddtp mode and ddtp context width               "
+
+#define RISCV_IOMMU_REG_CAP             0x0
+#define RISCV_IOMMU_CAP_MSIFLAT_MSK     (1 << 22)
+#define MSIFLAT_ENABLE                  (1 << 22)
+
+#define RISCV_IOMMU_REG_DDTP            0x10
+#define RISCV_IOMMU_DDTP_LVL_MSK        0xf
+#define RISCV_IOMMU_DDTP_LVL_1          2
+#define RISCV_IOMMU_DDTP_LVL_2          3
+#define RISCV_IOMMU_DDTP_LVL_3          4
+
+#define DDTP_LVL_1_BASE_WIDTH          7
+#define DDTP_LVL_2_BASE_WIDTH          16
+#define DDTP_LVL_3_BASE_WIDTH          24
+
+#define DDTP_LVL_1_EXTENDED_WIDTH      6
+#define DDTP_LVL_2_EXTENDED_WIDTH      15
+#define DDTP_LVL_3_EXTENDED_WIDTH      24
+
+static
+uint8_t
+check_iommu_cap_ddtp_reg(uint64_t reg_cap, uint64_t reg_ddtp, uint64_t max_deviceid)
+{
+    uint8_t ddtp_lvl1_bit = 0;
+    uint8_t ddtp_lvl2_bit = 0;
+    uint8_t ddtp_lvl3_bit = 0;
+    uint8_t ddtp_lvl_bit = 0;
+
+    if ((reg_cap & RISCV_IOMMU_CAP_MSIFLAT_MSK) != MSIFLAT_ENABLE) {
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap msi_flat- 0", 0);
+        ddtp_lvl1_bit = DDTP_LVL_1_BASE_WIDTH;
+        ddtp_lvl2_bit = DDTP_LVL_2_BASE_WIDTH;
+        ddtp_lvl3_bit = DDTP_LVL_3_BASE_WIDTH;
+    } else {
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap msi_flat- 1", 0);
+        ddtp_lvl1_bit = DDTP_LVL_1_EXTENDED_WIDTH;
+        ddtp_lvl2_bit = DDTP_LVL_2_EXTENDED_WIDTH;
+        ddtp_lvl3_bit = DDTP_LVL_3_EXTENDED_WIDTH;
+    }
+    if ((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) == RISCV_IOMMU_DDTP_LVL_1) {
+        ddtp_lvl_bit = ddtp_lvl1_bit;
+    } else if ((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) == RISCV_IOMMU_DDTP_LVL_2) {
+        ddtp_lvl_bit = ddtp_lvl2_bit;
+    } else if ((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) == RISCV_IOMMU_DDTP_LVL_3) {
+        ddtp_lvl_bit = ddtp_lvl3_bit;
+    }
+
+    if (max_deviceid > (2 << ddtp_lvl_bit)) {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU does not support the device id width", 0);
+        return 0;
+    } else {
+        return 1;
+    }
+
+    return 0;
+}
+
+static
+uint8_t
+check_governing_iommu_info(uint32_t iommu_index, uint32_t iommu_offset)
+{
+  uint32_t iommu_num = val_iommu_get_num();
+  uint32_t destiommu_offset;
+  uint32_t index;
+  uint64_t reg_cap, reg_ddtp;
+  uint32_t destid_base;
+  uint32_t numids;
+  uint32_t idmap_index;
+  uint16_t idmap_num;
+
+  if (iommu_index >= iommu_num) {
+    val_print(ACS_PRINT_ERR, "\n       IOMMU index error - 0x%x", iommu_index);
+    return 0;
+  }
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) != EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+        idmap_num = val_iommu_get_idmap_num (index);
+        for (idmap_index = 0; idmap_index < idmap_num; idmap_index++) {
+            destiommu_offset = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_DEST_IOMMU_OFFSET);
+            val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe DEST IOMMU OFFSET: 0x%x", destiommu_offset);
+            if (destiommu_offset == iommu_offset) {
+                destid_base = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_DEST_ID_BASE);
+                numids = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_NUM_IDS);
+                val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe DEST ID BASE: 0x%x", destid_base);
+                val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe NUM IDS: 0x%x", numids);
+                reg_cap = val_iommu_read_iommu_reg(iommu_index, RISCV_IOMMU_REG_CAP, 2);
+                reg_ddtp = val_iommu_read_iommu_reg(iommu_index, RISCV_IOMMU_REG_DDTP, 2);
+                return check_iommu_cap_ddtp_reg(reg_cap, reg_ddtp, destid_base + numids);
+            }
+        }
+    }
+  }
+
+  return 0xff;
+}
+
+/**
+ * @brief For each IOMMU that does not govern a PCIe root port: . Parse the ACPI RIMT
+structure of that IOMMU to determine the widest device ID. . Verify that the ddtp
+supports a mode that supports the widest device ID.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint8_t iommu_rp_flag[iommu_num];
+  uint32_t bdf = 0;
+  uint32_t dp_type;
+  uint32_t tbl_index = 0;
+  uint8_t ret = 0xff;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t iommu_index;
+  uint32_t iommu_offset;
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  for (index = 0; index < iommu_num; index++) {
+    iommu_rp_flag[index] = 0;
+  }
+
+  while (tbl_index < bdf_tbl_ptr->num_entries) {
+
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RP) {
+        ret = val_iommu_check_governing_iommu (bdf, &iommu_index);
+        if (ret == 1) {
+          val_print(ACS_PRINT_ERR, "\n       Governing IOMMU index: 0x%x", iommu_index);
+          iommu_rp_flag [iommu_index] = 1;
+        }
+      }
+  }
+
+  for (index = 0; index < iommu_num; index++) {
+    if (iommu_rp_flag[index] == 1) {
+      continue;  // IOMMU is a RP IOMMU, skip it.
+    } else {
+      iommu_offset = val_iommu_get_info (index, IOMMU_INFO_IOMMU_OFFSET);
+      ret = check_governing_iommu_info(index, iommu_offset);
+      if (ret == 0) {
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+      }
+    }
+  }
+
+  if (ret == 1) {
+    val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  } else {
+    val_print(ACS_PRINT_ERR, "\n       SKIP: NO NON PCIE RP GOVERNING IOMMU NODE", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+
+  return;
+}
+
+uint32_t
+os_iom004_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom005.c
+++ b/test_pool/iommu/operating_system/test_os_iom005.c
@@ -1,0 +1,113 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 5)
+#define TEST_RULE  "ME_IOM_050_010"
+#define TEST_DESC  "Check IOMMU supported page mmu mode               "
+
+#define RISCV_IOMMU_REG_CAP             0x0
+#define RISCV_IOMMU_CAP_SV32_MSK        (1 << 8)
+#define RISCV_IOMMU_CAP_SV39_MSK        (1 << 9)
+#define RISCV_IOMMU_CAP_SV48_MSK        (1 << 10)
+#define RISCV_IOMMU_CAP_SV57_MSK        (1 << 11)
+
+#define SATP_MODE_SV39  0UL
+#define SATP_MODE_SV48  1UL
+#define SATP_MODE_SV57  2UL
+#define SATP_MODE_SV64  3UL
+
+/**
+ * @brief For each application processor hart:
+ * 1. Parse ISA string in ACPI RHCT table and determine the page based virtual
+ *    memory systems supported by the harts.
+ * 2. For each IOMMU in reported:
+ *    a. Verify that the capabilities register enumerates support for each of the
+ *    page based virtual memory system modes supported by the harts.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap;
+  char8_t *isa_string;
+  char8_t *ptr;
+  uint8_t mmu_type = 0xff;
+
+  isa_string = val_hart_get_isa_string(hart_index);
+
+  ptr = val_strstr(isa_string, "sv39");
+  if (ptr != NULL) {
+    mmu_type = SATP_MODE_SV39;
+  } else {
+    ptr = val_strstr(isa_string, "sv48");
+    if (ptr != NULL) {
+      mmu_type = SATP_MODE_SV48;
+    } else {
+      ptr = val_strstr(isa_string, "sv57");
+      if (ptr != NULL) {
+        mmu_type = SATP_MODE_SV57;
+      } else {
+        val_print(ACS_PRINT_ERR, "\n       ISA string does not contain sv39, sv48 or sv57", 0);
+        mmu_type = val_hart_get_mmu_type(hart_index);
+      }
+    }
+  }
+  val_print(ACS_PRINT_INFO, "\n       HART MMU TYPE: %d", mmu_type);
+  if (mmu_type == 0xff) {
+    val_print(ACS_PRINT_ERR, "\n       Did not found supportted mmu type", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+    return;
+  }
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+      if ((mmu_type == SATP_MODE_SV39) && (reg_cap & RISCV_IOMMU_CAP_SV39_MSK) != RISCV_IOMMU_CAP_SV39_MSK) {
+        val_print(ACS_PRINT_ERR, "\n       Unsupportted MMU TYPE : SATP_MODE_SV39", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      } else if ((mmu_type == SATP_MODE_SV48) && (reg_cap & RISCV_IOMMU_CAP_SV48_MSK) != RISCV_IOMMU_CAP_SV48_MSK) {
+        val_print(ACS_PRINT_ERR, "\n       Unsupportted MMU TYPE : SATP_MODE_SV48", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      } else if ((mmu_type == SATP_MODE_SV57) && (reg_cap & RISCV_IOMMU_CAP_SV57_MSK) != RISCV_IOMMU_CAP_SV57_MSK) {
+        val_print(ACS_PRINT_ERR, "\n       Unsupportted MMU TYPE : SATP_MODE_SV57", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom005_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom008.c
+++ b/test_pool/iommu/operating_system/test_os_iom008.c
@@ -1,0 +1,70 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 8)
+#define TEST_RULE  "ME_IOM_080_010"
+#define TEST_DESC  "Check IOMMU MSI MRIF AND AMO MRIF               "
+
+#define RISCV_IOMMU_REG_CAP              0x0
+#define RISCV_IOMMU_CAP_MSI_MRIF_MSK     (1 << 23)
+#define RISCV_IOMMU_CAP_AMO_MRIF_MSK     (1 << 21)
+#define RISCV_IOMMU_CAP_MSI_MRIF_BIT     (23UL)
+#define RISCV_IOMMU_CAP_AMO_MRIF_BIT     (21UL)
+
+
+/**
+ * @brief For each IOMMU, verify that if capabilities.MSI_MRIF is equal to
+ * capabilities.AMO_MRIF
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+      if (((reg_cap & RISCV_IOMMU_CAP_MSI_MRIF_MSK) >> RISCV_IOMMU_CAP_MSI_MRIF_BIT) \
+          != (reg_cap & RISCV_IOMMU_CAP_AMO_MRIF_MSK) >> RISCV_IOMMU_CAP_AMO_MRIF_BIT) {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU reg_cap MSI_MRIF - 0x%lx", (reg_cap & RISCV_IOMMU_CAP_MSI_MRIF_MSK) >> RISCV_IOMMU_CAP_MSI_MRIF_BIT);
+        val_print(ACS_PRINT_ERR, "\n       IOMMU reg_cap AMO_MRIF - 0x%lx", (reg_cap & RISCV_IOMMU_CAP_AMO_MRIF_MSK) >> RISCV_IOMMU_CAP_AMO_MRIF_BIT);
+        val_print(ACS_PRINT_ERR, "\n       MSI_MRIF NOT EQUAL TO AMO MRIF", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_iom008_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom011.c
+++ b/test_pool/iommu/operating_system/test_os_iom011.c
@@ -1,0 +1,127 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 11)
+#define TEST_RULE  "ME_IOM_110_010"
+#define TEST_DESC  "Check RCiEP and Governing IOMMU ATS capability               "
+
+#define RISCV_IOMMU_REG_CAP         0x0
+#define RISCV_IOMMU_CAP_ATS_MSK     (1 << 25)
+#define RISCV_IOMMU_CAP_ATS_BIT     (25UL)
+
+#define ATS_CAP_ID    0xF
+
+static
+uint8_t
+check_pcie_ext_cap_ats(uint32_t bdf, uint32_t ext_cap_id)
+{
+  uint32_t next_cap_offset;
+  uint32_t reg_value;
+
+  next_cap_offset = PCIE_ECAP_START;
+  while (next_cap_offset)
+  {
+      val_pcie_read_cfg(bdf, next_cap_offset, &reg_value);
+      if ((reg_value & PCIE_ECAP_CIDR_MASK) == ext_cap_id)
+      {
+          return 1;
+      }
+      next_cap_offset = ((reg_value >> PCIE_ECAP_NCPR_SHIFT) & PCIE_ECAP_NCPR_MASK);
+  }
+
+  return 0;
+}
+
+/**
+ * @brief 1. Use PCIe discovery to locate all RCiEPs.
+ * 2. For each RCiEP:
+ *  a. If PCIe ATS capability not supported by the RCiEP then continue.
+ *  b. Locate the governing IOMMU using ACPI RIMT table.
+ *  c. Verify that the capabilities.ATS is 1 in the governing IOMMU.
+ */
+static
+void
+payload()
+{
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap;
+  uint32_t bdf = 0;
+  uint32_t dp_type;
+  uint32_t tbl_index = 0;
+  uint32_t iommu_index = 0xff;
+  uint8_t ret = 0xff;
+  uint8_t ats_support = 0xff;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  while (tbl_index < bdf_tbl_ptr->num_entries) {
+
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RCiEP) {
+        ats_support = check_pcie_ext_cap_ats(bdf, ATS_CAP_ID);
+        if (ats_support == 1) {
+          // Check IOMMU ATS Capability
+          ret = val_iommu_check_governing_iommu (bdf, &iommu_index);
+          if (ret == 1) {
+            val_print(ACS_PRINT_ERR, "\n       Governing IOMMU index: 0x%x", iommu_index);
+            if (iommu_index > iommu_num) {
+              val_print(ACS_PRINT_ERR, "\n       Illegal Governing IOMMU index: 0x%x", iommu_index);
+              val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+              return;
+            }
+            reg_cap = val_iommu_read_iommu_reg(iommu_index, RISCV_IOMMU_REG_CAP, 2);
+            if (reg_cap & RISCV_IOMMU_CAP_ATS_MSK) {
+              val_print(ACS_PRINT_INFO, "\n       IOMMU ATS capability is supported", 0);
+              val_set_status(hart_index, RESULT_PASS(TEST_NUM, 0));
+            } else {
+              val_print(ACS_PRINT_ERR, "\n       IOMMU ATS capability is not supported", 0);
+              val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+              return;
+            }
+          } else {
+            val_print(ACS_PRINT_ERR, "\n       RCiEP Governing IOMMU is not exit", 0);
+            val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+            return;
+          }
+        } else {
+          val_print(ACS_PRINT_ERR, "\n       PCIe ATS capability not supported by the RCiEP", 0);
+          continue;
+        }
+      }
+  }
+
+  val_print(ACS_PRINT_ERR, "\n       RCiEP device is not exit or not support ATS capability", 0);
+  val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom011_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom013.c
+++ b/test_pool/iommu/operating_system/test_os_iom013.c
@@ -1,0 +1,69 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 13)
+#define TEST_RULE  "ME_IOM_130_010"
+#define TEST_DESC  "Check IOMMU interrupt generation support               "
+
+#define RISCV_IOMMU_REG_CAP         0x0
+#define RISCV_IOMMU_CAP_IGS_MSK     (3ULL << 28)
+#define RISCV_IOMMU_CAP_IGS_BIT     28UL
+
+#define RISCV_IOMMU_CAP_IGS_MSI      0
+#define RISCV_IOMMU_CAP_IGS_WSI      1
+#define RISCV_IOMMU_CAP_IGS_BOTH     2
+
+/**
+ * @brief For each IOMMU, verify that if capabilities.IGS is either 0 or 2.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+      if (((reg_cap & RISCV_IOMMU_CAP_IGS_MSK) >> RISCV_IOMMU_CAP_IGS_BIT) != RISCV_IOMMU_CAP_IGS_MSI \
+        && ((reg_cap & RISCV_IOMMU_CAP_IGS_MSK) >> RISCV_IOMMU_CAP_IGS_BIT) != RISCV_IOMMU_CAP_IGS_BOTH) {
+        val_print(ACS_PRINT_ERR, "\n       Incorrect IOMMU CAP IGS value - 0x%x", ((reg_cap & RISCV_IOMMU_CAP_IGS_MSK) >> RISCV_IOMMU_CAP_IGS_BIT));
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom013_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom014.c
+++ b/test_pool/iommu/operating_system/test_os_iom014.c
@@ -1,0 +1,106 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 14)
+#define TEST_RULE  "ME_IOM_140_010, OE_IOM_150_010"
+#define TEST_DESC  "Check IOMMU BIG-ENDIAN               "
+
+#define RISCV_IOMMU_REG_FCTL         0x8
+#define RISCV_IOMMU_FCTL_BE_MSK      1
+
+#define RISCV_IOMMU_FCTL_BE_RO_0      1
+#define RISCV_IOMMU_FCTL_BE_W         2
+
+/**
+ * @brief For each IOMMU, verify that if fctl.BE is either read-only zero or is writeable. Verify
+ * that the support is identical for all IOMMUs. If big-endian mode supported then emit
+ * the support status in the test output log.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_fctl_old;
+  uint64_t reg_fctl;
+  uint64_t reg_fctl_new;
+  static uint8_t be_mode = 0;
+  static uint8_t be_mode_next = 0x0;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      reg_fctl_old = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_FCTL, 1);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU read reg_fctl - 0x%lx", reg_fctl_old);
+      reg_fctl = reg_fctl_old;
+      if ((reg_fctl & RISCV_IOMMU_FCTL_BE_MSK) == 0) {
+        be_mode_next = RISCV_IOMMU_FCTL_BE_RO_0;
+        reg_fctl |= RISCV_IOMMU_FCTL_BE_MSK;
+      } else {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU fctl support big-endian", 0);
+        reg_fctl &= ~RISCV_IOMMU_FCTL_BE_MSK;
+      }
+      // Write IOMMU fctl reg to 1 or 0 and read it back to check if it is writeable
+      val_print(ACS_PRINT_INFO, "\n       IOMMU write reg_fctl - 0x%lx", reg_fctl);
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_FCTL, 1, reg_fctl);
+      reg_fctl_new = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_FCTL, 1);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU read reg_fctl again - 0x%lx", reg_fctl_new);
+      if ((reg_fctl_new == reg_fctl)) {
+        be_mode_next = RISCV_IOMMU_FCTL_BE_W;
+        val_print(ACS_PRINT_ERR, "\n       IOMMU fctl.be is writeable", 0);
+        if ((reg_fctl & RISCV_IOMMU_FCTL_BE_MSK) == 1) {
+          val_print(ACS_PRINT_ERR, "\n       IOMMU fctl support big-endian", 0);
+        }
+        // restore the original value
+        val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_FCTL, 1, reg_fctl_old);
+      }
+
+      if ((be_mode_next != RISCV_IOMMU_FCTL_BE_RO_0) && (be_mode_next != RISCV_IOMMU_FCTL_BE_W)) {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU fctl.be not read only zero and writeable", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+
+      if (index > 0) {
+        if (be_mode_next != be_mode) {
+          val_print(ACS_PRINT_ERR, "\n       be_mode_next:0x%x", be_mode_next);
+          val_print(ACS_PRINT_ERR, "\n       be_mode:0x%x", be_mode);
+          val_print(ACS_PRINT_ERR, "\n       IOMMU fctl.be not consistency", 0);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+      }
+      be_mode = be_mode_next;
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom014_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom017.c
+++ b/test_pool/iommu/operating_system/test_os_iom017.c
@@ -1,0 +1,78 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 17)
+#define TEST_RULE  "ME_IOM_170_010"
+#define TEST_DESC  "Check IOMMU PDT support               "
+
+#define RISCV_IOMMU_REG_CAP          0x0
+#define RISCV_IOMMU_CAP_PD8_MSK      (1ULL << 38)
+#define RISCV_IOMMU_CAP_PD17_MSK     (1ULL << 39)
+#define RISCV_IOMMU_CAP_PD20_MSK     (1ULL << 40)
+#define RISCV_IOMMU_CAP_PD8_BIT      38UL
+#define RISCV_IOMMU_CAP_PD17_BIT     39UL
+#define RISCV_IOMMU_CAP_PD20_BIT     40UL
+
+/**
+ * @brief For each IOMMU, verify that if any of the PD8, PD17, or PD20 bits are 1 in the
+ * capabilities register then PD20 bit must be 1.
+ * 
+ * IOMMU that supports PASID capability MUST support 20-bit PASID width and MAY support
+ * 8-bit and 17-bit PASID widths.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+      if (((reg_cap & RISCV_IOMMU_CAP_PD8_MSK) >> RISCV_IOMMU_CAP_PD8_BIT) == 1 \
+        || ((reg_cap & RISCV_IOMMU_CAP_PD17_MSK) >> RISCV_IOMMU_CAP_PD17_BIT) == 1 \
+        || ((reg_cap & RISCV_IOMMU_CAP_PD20_MSK) >> RISCV_IOMMU_CAP_PD20_BIT) == 1) {
+          if (((reg_cap & RISCV_IOMMU_CAP_PD20_MSK) >> RISCV_IOMMU_CAP_PD20_BIT) != 1) {
+            val_print(ACS_PRINT_ERR, "\n       IOMMU reg_cap PD8- 0x%lx", (reg_cap & RISCV_IOMMU_CAP_PD8_MSK) >> RISCV_IOMMU_CAP_PD8_BIT);
+            val_print(ACS_PRINT_ERR, "\n       IOMMU reg_cap PD17- 0x%lx", (reg_cap & RISCV_IOMMU_CAP_PD17_MSK) >> RISCV_IOMMU_CAP_PD17_BIT);
+            val_print(ACS_PRINT_ERR, "\n       IOMMU reg_cap PD20- 0x%lx", (reg_cap & RISCV_IOMMU_CAP_PD20_MSK) >> RISCV_IOMMU_CAP_PD20_BIT);
+            val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+            return;
+          }
+      }
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom017_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom019.c
+++ b/test_pool/iommu/operating_system/test_os_iom019.c
@@ -1,0 +1,183 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 19)
+#define TEST_RULE  "ME_IOM_190_010"
+#define TEST_DESC  "Check IOMMU HPM and cycles counter support               "
+
+#define RISCV_IOMMU_REG_CAP          0x0
+#define RISCV_IOMMU_CAP_HPM_MSK      (1ULL << 30)
+#define RISCV_IOMMU_CAP_HPM_BIT      30UL
+
+#define RISCV_IOMMU_REG_IOCOUNTOVF               88
+#define RISCV_IOMMU_REG_IOCOUNTINH               92
+#define RISCV_IOMMU_REG_IOCOUNT_CY_MSK           (1)
+#define RISCV_IOMMU_REG_IOCOUNT_HPM_MSK          0xFFFFFFFEULL
+
+#define RISCV_IOMMU_REG_IOHPMCYCLES               96
+#define RISCV_IOMMU_REG_IOHPMCYCLES_OF_MSK        (1ULL << 63)
+#define RISCV_IOMMU_REG_COUNTER_MSK               0xFFFFFFFFFFULL
+
+#define RISCV_IOMMU_REG_IOHPMCTRL1   104
+#define RISCV_IOMMU_REG_IOHPMCTRL2   112
+#define RISCV_IOMMU_REG_IOHPMCTRL3   120
+#define RISCV_IOMMU_REG_IOHPMCTRL4   128
+
+/**
+ * @brief For each IOMMU:
+ * 1. if capabilities.HPM is 0 then continue.
+ * 2. Verify iohpmcycles and its OF bit are writeable and the cycles counter is at least
+ *    40-bit wide.
+ * 3. Verify at least four programmable HPM counters are supported and the counters
+ *    for each are at least 40-bit wide.
+ * 4. Verify that the bits corresponding to the implemented HPM counters in
+ *    iocountovf and iocountinh are writeable.
+ * 5. Verify that the iohpmcycles is at least 40-bit wide.
+ * 6. Verify that the CY bit in iocountovf and iocountinh is writeable.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap, reg_iohpmcycles_old, reg_iohpmcycles, reg_iohpmcycles_new;
+  uint64_t reg_iohpmctrl_old, reg_iohpmctrl, reg_iohpmctrl_new;
+  uint64_t offset;
+  uint32_t reg_iocountovf_old, reg_iocountovf, reg_iocountovf_new;
+  uint32_t reg_iocountinh_old, reg_iocountinh, reg_iocountinh_new;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      // check if HPM is supported
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+      if (((reg_cap & RISCV_IOMMU_CAP_HPM_MSK) >> RISCV_IOMMU_CAP_HPM_BIT) == 0) {
+        continue;
+      }
+
+      // check if iohpmcycles and its OF bit are writeable and the cycles counter is at least 40-bit wide
+      reg_iohpmcycles_old = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_IOHPMCYCLES, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmcycles old - 0x%lx", reg_iohpmcycles_old);
+      if ((reg_iohpmcycles_old & RISCV_IOMMU_REG_IOHPMCYCLES_OF_MSK) == 0) {
+        reg_iohpmcycles = reg_iohpmcycles_old | RISCV_IOMMU_REG_IOHPMCYCLES_OF_MSK;
+      } else {
+        reg_iohpmcycles = reg_iohpmcycles_old & (~RISCV_IOMMU_REG_IOHPMCYCLES_OF_MSK);
+      }
+      reg_iohpmcycles = reg_iohpmcycles_old & (~RISCV_IOMMU_REG_COUNTER_MSK);
+      reg_iohpmcycles = reg_iohpmcycles_old | RISCV_IOMMU_REG_COUNTER_MSK;
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmcycles - 0x%lx", reg_iohpmcycles);
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_IOHPMCYCLES, 2, reg_iohpmcycles);
+      reg_iohpmcycles_new = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_IOHPMCYCLES, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmcycles_new - 0x%lx", reg_iohpmcycles_new);
+      if (reg_iohpmcycles_new < reg_iohpmcycles) {      // counter is still runing
+        val_print(ACS_PRINT_ERR, "\n       IOMMU reg_iohpmcycles is not writeable or counter are not support 40-bits width", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+      // write back the old value
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_IOHPMCYCLES, 2, reg_iohpmcycles_old);
+
+      // check if at least four programmable HPM counters are supported and the counters for each are at least 40-bit wide
+      for (uint8_t count = 0; count < 4; count++) {
+        offset = RISCV_IOMMU_REG_IOHPMCTRL1 + 8 * count;
+        reg_iohpmctrl_old = val_iommu_read_iommu_reg(index, offset, 2);
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmctrl old- 0x%lx", reg_iohpmctrl_old);
+        reg_iohpmctrl = reg_iohpmctrl_old & (~RISCV_IOMMU_REG_COUNTER_MSK);
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmctrl - 0x%lx", reg_iohpmctrl);
+        val_iommu_write_iommu_reg(index, offset, 2, reg_iohpmctrl);
+        reg_iohpmctrl_new = val_iommu_read_iommu_reg(index, offset, 2);
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmctrl_new - 0x%lx", reg_iohpmctrl_new);
+        if (reg_iohpmctrl_new != reg_iohpmctrl) {
+          val_print(ACS_PRINT_ERR, "\n       IOMMU is not support 4 HPM or counter are not support 40-bits wide", 0);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+        reg_iohpmctrl = reg_iohpmctrl_old | RISCV_IOMMU_REG_COUNTER_MSK;
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmctrl 1- 0x%lx", reg_iohpmctrl);
+        val_iommu_write_iommu_reg(index, offset, 2, reg_iohpmctrl);
+        reg_iohpmctrl_new = val_iommu_read_iommu_reg(index, offset, 2);
+        val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iohpmctrl_new 1 - 0x%lx", reg_iohpmctrl_new);
+        if (reg_iohpmctrl_new != reg_iohpmctrl) {
+          val_print(ACS_PRINT_ERR, "\n       IOMMU is not support 4 HPM or counter are not support 40-bits wide", 0);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+        // restore the old value
+        val_iommu_write_iommu_reg(index, offset, 2, reg_iohpmcycles_old);
+      }
+
+      // check if the iocountovf HPM bits and CY bit are writeable
+      reg_iocountovf_old = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTOVF, 1);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iocountovf_old - 0x%lx", reg_iocountovf_old);
+      if ((reg_iocountovf_old & RISCV_IOMMU_REG_IOCOUNT_CY_MSK) == 0) {
+        reg_iocountovf = reg_iocountovf_old | RISCV_IOMMU_REG_IOCOUNT_CY_MSK;
+      } else {
+        reg_iocountovf = reg_iocountovf_old & (~RISCV_IOMMU_REG_IOCOUNT_CY_MSK);
+      }
+      reg_iocountovf = reg_iocountovf_old & (~RISCV_IOMMU_REG_IOCOUNT_HPM_MSK);
+      reg_iocountovf = reg_iocountovf_old | RISCV_IOMMU_REG_IOCOUNT_HPM_MSK;
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iocountovf - 0x%lx", reg_iocountovf);
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTOVF, 1, reg_iocountovf);
+      reg_iocountovf_new = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTOVF, 1);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iocountovf_new - 0x%lx", reg_iocountovf_new);
+      if (reg_iocountovf_new != reg_iocountovf) {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU iocountovf register is not writeable", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTOVF, 1, reg_iocountovf_old);
+
+      // check if the iocountinh HPM bits and CY bit are writeable
+      reg_iocountinh_old = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTINH, 1);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iocountinh_old - 0x%lx", reg_iocountinh_old);
+      if ((reg_iocountinh_old & RISCV_IOMMU_REG_IOCOUNT_CY_MSK) == 0) {
+        reg_iocountinh = reg_iocountinh_old | RISCV_IOMMU_REG_IOCOUNT_CY_MSK;
+      } else {
+        reg_iocountinh = reg_iocountinh_old & (~RISCV_IOMMU_REG_IOCOUNT_CY_MSK);
+      }
+      reg_iocountinh = reg_iocountinh_old & (~RISCV_IOMMU_REG_IOCOUNT_HPM_MSK);
+      reg_iocountinh = reg_iocountinh_old | RISCV_IOMMU_REG_IOCOUNT_HPM_MSK;
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iocountovf - 0x%lx", reg_iocountinh);
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTINH, 1, reg_iocountinh);
+      reg_iocountinh_new = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTINH, 1);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_iocountovf_new - 0x%lx", reg_iocountinh_new);
+      if (reg_iocountinh_new != reg_iocountinh) {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU iocountovf register is not writeable", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+      val_iommu_write_iommu_reg(index, RISCV_IOMMU_REG_IOCOUNTINH, 1, reg_iocountinh_old);
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom019_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom022.c
+++ b/test_pool/iommu/operating_system/test_os_iom022.c
@@ -1,0 +1,96 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include <sbi/riscv_asm.h>
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 22)
+#define TEST_RULE  "ME_IOM_220_010"
+#define TEST_DESC  "Check IOMMU PPN width               "
+
+#define RISCV_IOMMU_REG_CAP          0x0
+#define RISCV_IOMMU_CAP_PAS_MSK      (0x3FULL << 32)
+#define RISCV_IOMMU_CAP_PAS_BIT      32UL
+
+#define CSR_REG_HGATP                0x680
+#define CSR_HGATP_MODE_MSK           (3ULL << 30)
+#define CSR_HGATP_MODE_BIT           30UL
+
+
+/**
+ * @brief 1. Determine the width of the PPN field in hgatp and multiply that by 4096 to
+ *  determine the PA size supported by the hart.
+ * 2. Verify that the capabilities.PAS is greater than equal to the PA size supported
+ *  by the hart.
+ */
+static
+void
+payload()
+{
+  uint32_t index;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_cap;
+  uint8_t iommu_pas;
+  uint8_t hgatp_mode;
+  uint8_t pa_bits;
+
+  hgatp_mode = (csr_read(CSR_REG_HGATP) & CSR_HGATP_MODE_MSK) >> CSR_HGATP_MODE_BIT;
+  val_print(ACS_PRINT_INFO, "\n       HGATP mode - 0x%x", hgatp_mode);
+  if (hgatp_mode == 0) {
+    val_print(ACS_PRINT_ERR, "\n       HGATP mode is bare mode- no translation or protection", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+    return;
+  }
+
+  switch (hgatp_mode) {
+    case 0x8:           // Sv39/Sv39x4
+    case 0x9:           // Sv48/Sv48x4
+    case 0xA:           // Sv57/Sv57x4
+      pa_bits = 56 - 12; 
+      break;
+    case 0x1:           // Sv32x4 (RV32)
+      pa_bits = 34 - 12;
+      break;
+  }
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      reg_cap = val_iommu_read_iommu_reg(index, RISCV_IOMMU_REG_CAP, 2);
+      val_print(ACS_PRINT_INFO, "\n       IOMMU reg_cap - 0x%lx", reg_cap);
+      iommu_pas = (reg_cap & RISCV_IOMMU_CAP_PAS_MSK) >> RISCV_IOMMU_CAP_PAS_BIT;
+      val_print(ACS_PRINT_INFO, "\n       IOMMU PAS - 0x%x", iommu_pas);
+      if (iommu_pas <= pa_bits*4096) {
+        val_print(ACS_PRINT_ERR, "\n       IOMMU PAS is not greater than equal to PA size", 0);
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+      }
+    }
+  }
+
+  val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom022_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom024.c
+++ b/test_pool/iommu/operating_system/test_os_iom024.c
@@ -1,0 +1,74 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 24)
+#define TEST_RULE  "ME_IOM_240_010"
+#define TEST_DESC  "Check RCiEP IOMMU device               "
+
+#define PCIE_BASECLASS_IOMMU              0x08
+#define PCIE_SUBCLASS_IOMMU               0x06
+
+/**
+ * @brief 1. Do a PCIe scan to locate all RCiEP of IOMMU class and report the
+ * bus:device:function numbers of the IOMMUs in the test output log.
+ */
+static
+void
+payload()
+{
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t bdf = 0;
+  uint32_t dp_type;
+  uint32_t class_code;
+  uint32_t tbl_index = 0;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  while (tbl_index < bdf_tbl_ptr->num_entries) {
+     bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+
+    dp_type = val_pcie_device_port_type(bdf);
+    if (dp_type == RCiEP) {
+      val_pcie_read_cfg(bdf, TYPE01_RIDR, &class_code);
+      if ((((class_code >> CC_BASE_SHIFT) & CC_BASE_MASK) == PCIE_BASECLASS_IOMMU) &&
+           (((class_code >> CC_SUB_SHIFT) & CC_SUB_MASK)) == PCIE_SUBCLASS_IOMMU) {
+        val_print(ACS_PRINT_DEBUG, "\n       Find RCiEP IOMMU Device, BDF - 0x%x", bdf);
+        val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+        val_print(ACS_PRINT_ERR, "\n       Bus - %d", (bdf & 0x00ff0000) >> 16);
+        val_print(ACS_PRINT_ERR, "\n       Dev - %d", (bdf & 0x0000ff00) >> 8);
+        val_print(ACS_PRINT_ERR, "\n       Func - %d", bdf & 0x000000ff);
+        return;
+      }
+    }
+  }
+
+  val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  return;
+}
+
+uint32_t
+os_iom024_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/iommu/operating_system/test_os_iom026.c
+++ b/test_pool/iommu/operating_system/test_os_iom026.c
@@ -1,0 +1,182 @@
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+#include "val/include/bsa_acs_memory.h"
+
+#include "val/include/bsa_acs_iommu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_IOMMU_TEST_NUM_BASE + 26)
+#define TEST_RULE  "ME_IOM_260_010"
+#define TEST_DESC  "Check IOMMU DDTP which governing multiple segment PCIe RC               "
+
+#define RISCV_IOMMU_REG_DDTP            0x10
+#define RISCV_IOMMU_DDTP_LVL_MSK        0xf
+#define RISCV_IOMMU_DDTP_LVL_1          2
+#define RISCV_IOMMU_DDTP_LVL_2          3
+#define RISCV_IOMMU_DDTP_LVL_3          4
+
+#define IOMMU_MAP_MAX             30
+
+typedef struct {
+  uint32_t iommu_index;
+  uint32_t pcierc_index;
+  uint32_t pcierc_seg;
+} IOMMU_MAP;
+
+static
+uint8_t
+check_iommu_ddtp_level(uint32_t iommu_index)
+{
+  uint32_t iommu_num = val_iommu_get_num();
+  uint64_t reg_ddtp;
+
+  if (iommu_index >= iommu_num) {
+    val_print(ACS_PRINT_ERR, "\n       IOMMU index error - 0x%x", iommu_index);
+    return 0;
+  }
+
+  reg_ddtp = val_iommu_read_iommu_reg(iommu_index, RISCV_IOMMU_REG_DDTP, 2);
+  val_print(ACS_PRINT_INFO, "\n       IOMMU reg_ddtp - 0x%lx", reg_ddtp);
+  if ((reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK) != RISCV_IOMMU_DDTP_LVL_3) {
+    val_print(ACS_PRINT_ERR, "\n       IOMMU ddtp level id not 3 level - 0x%x", reg_ddtp & RISCV_IOMMU_DDTP_LVL_MSK);
+    return 0;
+  } 
+
+  return 1;
+}
+
+static
+uint8_t
+check_governing_iommu (uint32_t destiommu_offset, uint32_t *iommu_index)
+{
+  uint32_t iommu_num = val_iommu_get_num();
+  uint32_t iommu_offset;
+  uint32_t index;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      iommu_offset = val_iommu_get_info (index, IOMMU_INFO_IOMMU_OFFSET);
+      if (destiommu_offset == iommu_offset) {
+        *iommu_index = index;
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+ * @brief 1. Parse the PCIe root complex device binding structures from ACPI RIMT table
+ *   and build a mapping of root complexes associated with each IOMMU.
+ * 2. For each IOMMU determine the PCIe segment number of the associated PCIe
+ *   root complexes and create a list of IOMMUs that govern multiple root complexes
+ *   where the PCIe root complexes belong to two or more PCIe segments.
+ * 3. For each IOMMU that governs PCIe root complexes that are part of different
+ *   PCIe segments verify that the ddtp supports 3 level DDT.
+ */
+static
+void
+payload()
+{
+  uint32_t index,index1;
+  uint32_t hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  uint32_t iommu_num = val_iommu_get_num();
+  uint8_t ret = 0xff;
+  uint32_t iommu_index;
+  uint32_t iommu_offset;
+  uint8_t map_index = 0;
+  uint8_t iommu_multi_list[iommu_num];
+  uint8_t idmap_num;
+  uint8_t idmap_index;
+  IOMMU_MAP iommu_map[IOMMU_MAP_MAX];
+
+  for (index = 0; index < IOMMU_MAP_MAX; index++) {
+    iommu_map[index].iommu_index = 0xff;
+  }
+  for (index = 0; index < iommu_num; index++) {
+    iommu_multi_list[index] = 0xff;
+  }
+
+  //Get the PCIe root complex device binding structures from ACPI RIMT table
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_PCIE_ROOT_COMPLEX) {
+      idmap_num = val_iommu_get_idmap_num (index);
+      for (idmap_index = 0; idmap_index < idmap_num; idmap_index++) {
+        iommu_offset = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_DEST_IOMMU_OFFSET);
+        val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe DEST IOMMU OFFSET: 0x%x", iommu_offset);
+        ret = check_governing_iommu (iommu_offset, &iommu_index);
+        if (ret == 1) {
+          val_print(ACS_PRINT_ERR, "\n       Governing IOMMU index: 0x%x", iommu_index);
+          if ((iommu_index < iommu_num) && (map_index < IOMMU_MAP_MAX)) {
+            iommu_map [map_index].iommu_index = iommu_index;
+            iommu_map [map_index].pcierc_index = index;
+            iommu_map [map_index].pcierc_seg = val_iommu_get_pcierc_platform_info(index, 0, IOMMU_INFO_PCIE_RC_SEG);
+            map_index++;
+          }
+        }
+      }
+    }
+  }
+
+  // Check if there is any IOMMU that governs PCIe root complexes that are part of different PCIe segments
+  val_print(ACS_PRINT_ERR, "\n       IOMMU - PCIe Root Complex map table:", 0);
+  for (index = 0; index < IOMMU_MAP_MAX; index++) {
+    if (iommu_map[index].iommu_index != 0xff) {
+      val_print(ACS_PRINT_ERR, "\n         IOMMU index: 0x%x", iommu_map[index].iommu_index);
+      val_print(ACS_PRINT_ERR, "\n         PCIe RC index: 0x%x", iommu_map[index].pcierc_index);
+      val_print(ACS_PRINT_ERR, "\n         PCIe RC segment: 0x%x\n", iommu_map[index].pcierc_seg);
+    }
+  }
+
+  for (index = 0; index < IOMMU_MAP_MAX - 1; index++) {
+    for (index1 = index + 1; index1 < IOMMU_MAP_MAX; index1++) {
+      if ((iommu_map[index].iommu_index != 0xFF) \
+        && (iommu_map[index].iommu_index == iommu_map[index1].iommu_index) \
+        && (iommu_map[index].pcierc_seg != iommu_map[index1].pcierc_seg)) {
+          iommu_multi_list[iommu_index] = 1;
+          val_print(ACS_PRINT_ERR, "\n       IOMMU Multi index: 0x%x", iommu_map[index].iommu_index);
+      }
+    }
+  }
+
+  ret = 0xff;
+  for (index = 0; index < iommu_num; index++) {
+    if (iommu_multi_list[index] == 1) {
+      ret = check_iommu_ddtp_level(index);
+      if (ret == 0) {
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+      }
+    }
+  }
+
+  if (ret == 1) {
+    val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  } else {
+    val_print(ACS_PRINT_ERR, "\n       SKIP: NO MULTIPLE SEGMENT PCIE RP GOVERNING IOMMU NODE", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+
+  return;
+}
+
+uint32_t
+os_iom026_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This IOMMU test is run on single processor
+  // TODO: test all processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p002.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p002.c
@@ -1,0 +1,214 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define DEVICE_NUM_PER_BUS   256
+#define MEM_SIZE_PER_DEVICE  4096
+#define MAX_ECAM_NUM         20
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 2)
+#define TEST_RULE  "MF_ECM_030_010, MF_ECM_040_010"
+#define TEST_DESC  "Check the continuity and non-overlapping of ECAM at different hierarchies  "
+
+typedef struct {
+  uint64_t base;
+  uint64_t size;
+  uint32_t segment;
+  uint32_t start_bus;
+  uint32_t end_bus;
+} ecam_space;
+
+static ecam_space ecam_data[MAX_ECAM_NUM];
+
+static void *branch_to_test;
+
+static
+void
+esr(uint64_t interrupt_type, void *context)
+{
+  uint32_t hart_index;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Update the ELR to return to test specified address */
+  val_hart_update_elr(context, (uint64_t)branch_to_test);
+
+  val_print(ACS_PRINT_INFO, "\n       Received exception of type: %d", interrupt_type);
+  val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+}
+
+void sort_ecam_data(uint32_t num_ecam) 
+{
+  ecam_space temp;
+  uint8_t i, j;
+
+  for (i = 0; i < num_ecam - 1; i++) {
+    for (j = 0; j < num_ecam - 1 - i; j++) {
+      if (ecam_data[j].segment > ecam_data[j + 1].segment ||
+        (ecam_data[j].segment == ecam_data[j + 1].segment &&
+        ecam_data[j].start_bus > ecam_data[j + 1].start_bus)) {
+          temp = ecam_data[j];
+          ecam_data[j] = ecam_data[j + 1];
+          ecam_data[j + 1] = temp;
+      }
+    }
+  }
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t num_ecam;
+  uint64_t ecam_base;
+  uint64_t ecam_size;
+  uint32_t index;
+  uint32_t bus, next_bus, segment;
+  uint32_t end_bus;
+  uint32_t status;
+  uint32_t ecam_index;
+  uint64_t current_ecam_base = 0;
+  uint64_t current_ecam_size = 0;
+  uint64_t next_ecam_base = 0;
+  uint64_t next_ecam_size = 0;
+
+  index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Install sync and async handlers to handle exceptions.*/
+  status = val_hart_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
+  status |= val_hart_install_esr(EXCEPT_AARCH64_SERROR, esr);
+  if (status)
+  {
+      val_print(ACS_PRINT_ERR, "\n      Failed in installing the exception handler", 0);
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+      return;
+  }
+
+  branch_to_test = &&exception_return;
+
+  num_ecam = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
+  if (num_ecam == 0) {
+      val_print(ACS_PRINT_DEBUG, "\n       No ECAM in MCFG                   ", 0);
+      val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+      return;
+  }
+
+  while (num_ecam) {
+      num_ecam--;
+      ecam_base = val_pcie_get_info(PCIE_INFO_ECAM, num_ecam);
+      if (ecam_base == 0) {
+          val_print(ACS_PRINT_ERR, "\n       ECAM Base in MCFG is 0            ", 0);
+          val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+          return;
+      }
+
+      segment = val_pcie_get_info(PCIE_INFO_SEGMENT, num_ecam);
+      bus = val_pcie_get_info(PCIE_INFO_START_BUS, num_ecam);
+      end_bus = val_pcie_get_info(PCIE_INFO_END_BUS, num_ecam);
+
+      ecam_size = (end_bus - bus + 1) * DEVICE_NUM_PER_BUS * MEM_SIZE_PER_DEVICE;
+      ecam_data[num_ecam].base = ecam_base;
+      ecam_data[num_ecam].size = ecam_size;
+      ecam_data[num_ecam].segment = segment;
+      ecam_data[num_ecam].start_bus = bus;
+      ecam_data[num_ecam].end_bus = end_bus;
+      val_print(ACS_PRINT_INFO, "\n       ECAM Base in MCFG is 0x%lx", ecam_base);
+      val_print(ACS_PRINT_INFO, "\n       ECAM Base in MCFG segment is 0x%lx", segment);
+      val_print(ACS_PRINT_INFO, "\n       ECAM Base in MCFG start_bus is 0x%lx", bus);
+      val_print(ACS_PRINT_INFO, "\n       ECAM Base in MCFG end_bus is 0x%lx", end_bus);
+      val_print(ACS_PRINT_INFO, "\n       ECAM Base in MCFG size is 0x%lx", ecam_size);
+  }
+
+  // Sort ECAM data by segment and start_bus
+  if (num_ecam > 1) {
+    sort_ecam_data(num_ecam);
+  }
+
+  // Check ECAM continuity and non-overlapping
+  for (ecam_index = 0; ecam_index < num_ecam; ecam_index++) {
+    current_ecam_base = ecam_data[ecam_index].base;
+    current_ecam_size = ecam_data[ecam_index].size;
+    if ((ecam_index + 1) < num_ecam) {
+      // Check BUS continuity under same segment
+      if (ecam_data[ecam_index].segment == ecam_data[ecam_index + 1].segment) {
+        bus = ecam_data[ecam_index].start_bus;
+        end_bus = ecam_data[ecam_index].end_bus;
+        next_bus = ecam_data[ecam_index + 1].start_bus;
+        if ((end_bus + 1) != next_bus) {
+          val_print(ACS_PRINT_ERR, "\n       Bus in MCFG is not continuous", 0);
+          val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+
+        // Check ECAM address continuity
+        next_ecam_base = ecam_data[ecam_index + 1].base;
+        if ((current_ecam_base + current_ecam_size) != next_ecam_base) {
+          val_print(ACS_PRINT_ERR, "\n       ECAM %d base address is not continuous            ", ecam_index);
+          val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+      } else if (ecam_data[ecam_index].segment != ecam_data[ecam_index + 1].segment) {
+        // Check ECAM address overlap between different segments
+        next_ecam_base = ecam_data[ecam_index + 1].base;
+        next_ecam_size = ecam_data[ecam_index + 1].size;
+        if (((current_ecam_base + current_ecam_size) >= next_ecam_base)
+          && ((next_ecam_base + next_ecam_size) >= current_ecam_base)) {
+          val_print(ACS_PRINT_ERR, "\n       ECAM %d base address is overlap            ", ecam_index);
+          val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+          return;
+        }
+      }
+    }
+
+    // Check ECAM address alignment with size
+    if (current_ecam_base % current_ecam_size != 0) {
+      val_print(ACS_PRINT_ERR, "\n       ECAM %d base address is not naturally aligned to the size            ", ecam_index);
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+      return;
+    }
+  }
+
+  val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+
+exception_return:
+  return;
+}
+
+uint32_t
+os_p002_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p003.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p003.c
@@ -1,0 +1,200 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021,2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 3)
+#define TEST_RULE  "MF_ECAM_060_010"
+#define TEST_DESC  "Check access the configuration space when PCIe link down"
+
+uint32_t original_vendor[PCIE_MAX_DEV][PCIE_MAX_FUNC];
+
+static
+uint32_t
+check_bdf_under_rp(uint32_t rp_bdf)
+{
+  uint32_t reg_value;
+  uint32_t rp_sec_bus, rp_sub_bus;
+  uint32_t dev_bdf, dev_bus, dev_sec_bus;
+  uint32_t rp_seg, dev_seg;
+  uint32_t base_cc;
+  uint32_t dev_num, func_num;
+
+  rp_seg = PCIE_EXTRACT_BDF_SEG(rp_bdf);
+  val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
+  rp_sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
+  rp_sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+
+  for (dev_sec_bus = rp_sec_bus; dev_sec_bus <= rp_sub_bus; dev_sec_bus++)
+  {
+      for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
+      {
+          for (func_num = 0; func_num < PCIE_MAX_FUNC; func_num++)
+          {
+              dev_bdf = PCIE_CREATE_BDF(rp_seg, dev_sec_bus, dev_num, func_num);
+              val_pcie_read_cfg(dev_bdf, TYPE01_VIDR, &reg_value);
+              if (reg_value == PCIE_UNKNOWN_RESPONSE)
+                  continue;
+
+              dev_bus = PCIE_EXTRACT_BDF_BUS(dev_bdf);
+              dev_seg = PCIE_EXTRACT_BDF_SEG(dev_bdf);
+              if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
+              {
+                  val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
+                  val_print(ACS_PRINT_DEBUG, "\n       Class code is 0x%x", reg_value);
+                  base_cc = reg_value >> TYPE01_BCC_SHIFT;
+                  if ((base_cc != CNTRL_CC) && (base_cc != DP_CNTRL_CC) && (base_cc != MAS_CC))
+                      return 1;
+              }
+           }
+       }
+  }
+
+   return 0;
+}
+
+static
+uint8_t
+enumerate_pcie_device (uint8_t segment_num, uint8_t bus_num, uint8_t first)
+{
+  uint8_t dev_index;
+  uint8_t func_index;
+  uint32_t bdf;
+  uint32_t vendor;
+
+  for (dev_index = 0; dev_index < PCIE_MAX_DEV; dev_index++) {
+    for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++) {
+      bdf = PCIE_CREATE_BDF(segment_num, bus_num, dev_index, func_index);
+      val_pcie_read_cfg_width(bdf, TYPE01_VIDR, &vendor, PCI_WIDTH_UINT32);
+      if (first) {
+        original_vendor[dev_index][func_index] = vendor;
+        // val_print(ACS_PRINT_INFO, "\n       Vendor ID is 0x%04x ", vendor);
+      } else if (vendor != original_vendor[dev_index][func_index]) {
+        val_print(ACS_PRINT_ERR, "\n       Vendor ID is changed from 0x%04x ", original_vendor[dev_index][func_index]);
+        val_print(ACS_PRINT_ERR, "\n       Vendor ID is changed to 0x%04x ", vendor);
+        return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t test_skip;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint8_t p_bus;
+  uint8_t p_seg;
+  uint8_t ret;
+  uint32_t cap_base;
+  uint32_t reg_value = 0xFFFFFFFF;
+
+  tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  test_skip = 1;
+
+  while (tbl_index < bdf_tbl_ptr->num_entries) {
+      /*
+       * If a function is in the hierarchy domain
+       * originated by a Root Port, check its ECAM
+       * is same as its RootPort ECAM.
+       */
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RP) {
+        /** Skip Check_2 if there is an Ethernet or Display controller under the RP device **/
+        if (check_bdf_under_rp(bdf) == 0) {
+            val_print(ACS_PRINT_DEBUG, "\n       Skipping for RP BDF 0x%x", bdf);
+            continue;
+        } else {
+            p_seg = PCIE_EXTRACT_BDF_SEG(bdf);
+            val_print(ACS_PRINT_DEBUG, "\n       Root port segment number is 0x%x", p_seg);
+            p_bus = PCIE_EXTRACT_BDF_BUS(bdf);
+            val_print(ACS_PRINT_DEBUG, "\n       Root port bus number is 0x%x", p_bus);
+            test_skip = 0;
+            break;
+        }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+          "\n       No RP type device for test found. Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+      return;
+  }
+
+  /* Accessing the BDF PCIe config range first time*/
+  ret = enumerate_pcie_device(p_seg, p_bus, 1);
+
+  /* Disable rp link*/
+  val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
+  val_pcie_read_cfg(bdf, cap_base + LCTRLR_OFFSET, &reg_value);
+  if ((reg_value & LINK_DISABLE_SHIFT) != LINK_DISABLE) {
+     val_print(ACS_PRINT_ERR, "\n       Link control is not link disable and disable it", 0);
+     reg_value |= LINK_DISABLE;
+     val_pcie_write_cfg(bdf, cap_base + LCTRLR_OFFSET, reg_value);
+  }
+
+  /* Accessing the BDF PCIe config range second time*/
+  ret = enumerate_pcie_device(p_seg, p_bus, 0);
+  if (ret == 0) {
+    val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+  } else {
+    val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+  }
+
+  /* Enable rp link*/
+  if ((reg_value & LINK_DISABLE_SHIFT) == LINK_DISABLE) {
+     val_print(ACS_PRINT_ERR, "\n       Link control is link disable and relink it", 0);
+     reg_value &= ~LINK_DISABLE;
+     val_pcie_write_cfg(bdf, cap_base + LCTRLR_OFFSET, reg_value);
+  }
+
+}
+
+uint32_t
+os_p003_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p004.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p004.c
@@ -1,0 +1,92 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 4)
+#define TEST_RULE  "MF_ECM_070_010"
+#define TEST_DESC  "Check RootPort configuration RRS software visibility       "
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t cap_base;
+  uint16_t reg_value;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  tbl_index = 0;
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      if (dp_type == RP)
+      {
+        test_skip = 0;
+        /* check CSR support state */
+        val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
+        val_pcie_read_cfg_width(bdf, cap_base + ROOTCP_OFFSET, &reg_value, PCI_WIDTH_UINT16);
+        if ((reg_value & 0x01) != 0x01) {
+           val_print(ACS_PRINT_DEBUG,     "\n       RRS software visibility is not enabled on RP: 0x%x", bdf);
+           val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 1));
+           return;
+        }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+        "\n       No RP type device found.", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p004_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p005.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p005.c
@@ -1,0 +1,402 @@
+/** @file
+ * Copyright (c) 2020, 2022-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 5)
+#define TEST_RULE  "MF_ECM_090_010, MF_ECM_100_010"
+#define TEST_DESC  "Check configuration space access behavior under scenarios including: \
+            non-existent devices, post-FLR (Function Level Reset) devices, \
+            CRS (Configuration Request Retry Status) states, and link-down conditions......"
+
+static void *branch_to_test;
+
+static
+void
+esr(uint64_t interrupt_type, void *context)
+{
+  uint32_t hart_index;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Update the ELR to return to test specified address */
+  val_hart_update_elr(context, (uint64_t)branch_to_test);
+
+  val_print(ACS_PRINT_ERR, "\n       Received exception of type: %d", interrupt_type);
+  val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+}
+
+static
+uint32_t
+check_bdf_under_rp(uint32_t rp_bdf)
+{
+
+  uint32_t reg_value;
+  uint32_t rp_sec_bus, rp_sub_bus;
+  uint32_t dev_bdf, dev_bus, dev_sec_bus;
+  uint32_t rp_seg, dev_seg;
+  uint32_t base_cc;
+  uint32_t dev_num, func_num;
+  uint32_t cap_base;
+  uint8_t af_cap;
+
+  rp_seg = PCIE_EXTRACT_BDF_SEG(rp_bdf);
+  val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
+  rp_sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
+  rp_sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+
+  for (dev_sec_bus = rp_sec_bus; dev_sec_bus <= rp_sub_bus; dev_sec_bus++)
+  {
+      for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
+      {
+          for (func_num = 0; func_num < PCIE_MAX_FUNC; func_num++)
+          {
+              dev_bdf = PCIE_CREATE_BDF(rp_seg, dev_sec_bus, dev_num, func_num);
+              val_pcie_read_cfg(dev_bdf, TYPE01_VIDR, &reg_value);
+              if (reg_value == PCIE_UNKNOWN_RESPONSE)
+                  continue;
+
+              dev_bus = PCIE_EXTRACT_BDF_BUS(dev_bdf);
+              dev_seg = PCIE_EXTRACT_BDF_SEG(dev_bdf);
+              if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
+              {
+                  val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
+                  val_print(ACS_PRINT_DEBUG, "\n       Class code is 0x%x", reg_value);
+                  base_cc = reg_value >> TYPE01_BCC_SHIFT;
+                  if ((base_cc != CNTRL_CC) && (base_cc != DP_CNTRL_CC) && (base_cc != MAS_CC)) {
+                    /* Check this device support FLR */
+                    if (val_pcie_find_capability(dev_bdf, PCIE_ECAP, ECID_AF, &cap_base) == PCIE_SUCCESS) {
+                      val_pcie_read_cfg_width(dev_bdf, cap_base + AF_CAPABILITY_OFFSET, &af_cap, PCI_WIDTH_UINT8);
+                      if ((af_cap & FLR_CAP_EN) == FLR_CAP_EN) {
+                        return dev_bdf;
+                      }
+                    }
+                  }
+              }
+           }
+       }
+  }
+
+   return 0;
+}
+
+/* Returns the nf bdf value for that bus from bdf table */
+static 
+uint32_t 
+get_nf_bdf(uint32_t segment, uint32_t bus)
+{
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t seg_num;
+  uint32_t bus_num;
+  uint32_t dev_num, max_dev_num;
+  uint32_t func_num, max_func_num;
+  uint32_t bdf;
+  uint32_t tbl_index = 0;
+  uint32_t nf_bdf = 0;
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  max_dev_num = 0;
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      seg_num = PCIE_EXTRACT_BDF_SEG(bdf);
+      bus_num = PCIE_EXTRACT_BDF_BUS(bdf);
+      dev_num = PCIE_EXTRACT_BDF_DEV(bdf);
+
+      if ((segment == seg_num) && (bus_num == bus) && (dev_num > max_dev_num)) {
+        max_dev_num = dev_num;
+      }
+  }
+
+  max_func_num = 0;
+  if (max_dev_num == (PCIE_MAX_DEV - 1)) {
+    for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+    {
+        bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+        seg_num = PCIE_EXTRACT_BDF_SEG(bdf);
+        bus_num = PCIE_EXTRACT_BDF_BUS(bdf);
+        dev_num = PCIE_EXTRACT_BDF_DEV(bdf);
+        func_num = PCIE_EXTRACT_BDF_FUNC(bdf);
+
+        if ((segment == seg_num) && (bus_num == bus) && (dev_num == max_dev_num) && (func_num > max_func_num)) {
+          max_func_num = func_num;
+        }
+    }
+  }
+
+  if (max_dev_num != (PCIE_MAX_DEV - 1)) {
+    nf_bdf = PCIE_CREATE_BDF(segment, bus, (max_dev_num + 1), max_func_num);
+  } else if (max_func_num != (PCIE_MAX_FUNC - 1)) {
+    nf_bdf = PCIE_CREATE_BDF(segment, bus, max_dev_num, (max_func_num + 1));
+  }
+  val_print(ACS_PRINT_DEBUG, "\n NF Device dev num 0x%x", nf_bdf);
+  return nf_bdf;
+}
+
+static
+uint32_t
+wait_device_discovery(uint32_t bdf)
+{
+  uint32_t retry = 1000;
+  uint32_t reg_value = 0;
+  uint32_t timeout = TIMEOUT_MEDIUM;
+
+  for (int i = 0; i < retry; i++) {
+    val_pcie_read_cfg_width(bdf, TYPE01_VIDR, &reg_value, PCI_WIDTH_UINT32);
+    if (reg_value != 0xFFFFFFFF){
+      return 1;
+    }
+    while ((--timeout > 0)){};
+  }
+  return 0;
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t reg_value;
+  uint32_t cap_base;
+  uint32_t af_cap_base;
+  uint32_t status;
+  uint32_t test_skip = 1;
+  uint32_t rp_bus;
+  uint32_t rp_seg;
+  uint32_t nf_bdf;
+  uint32_t dev_bdf;
+  uint32_t ret;
+  uint16_t reg_value16;
+  uint8_t flr_reg;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Install sync and async handlers to handle exceptions.*/
+  status = val_hart_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
+  status |= val_hart_install_esr(EXCEPT_AARCH64_SERROR, esr);
+  if (status)
+  {
+      val_print(ACS_PRINT_ERR, "\n       Failed in installing the exception handler", 0);
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+      return;
+  }
+
+  branch_to_test = &&exception_return;
+
+  tbl_index = 0;
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      if (dp_type == RP)
+      {
+        rp_seg = PCIE_EXTRACT_BDF_SEG(bdf);
+        rp_bus = PCIE_EXTRACT_BDF_BUS(bdf);
+        test_skip = 0;
+
+        /* 1.Check RP header type is type 1 */
+        if (val_pcie_function_header_type(bdf) != TYPE1_HEADER) {
+          val_print(ACS_PRINT_ERR, "\n       RP header type is not type1 for BDF  0x%x", bdf);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+          return;
+        }
+
+        /* 2.Check all 1's for NF device's vendorid */
+        nf_bdf = get_nf_bdf(rp_seg, rp_bus);
+        if (nf_bdf == 0) {
+          val_print(ACS_PRINT_DEBUG, "\n       No NF Device under rp_bus 0x%x", bdf);
+        } else {
+          ret = val_pcie_read_cfg_width(nf_bdf, TYPE01_VIDR, &reg_value, PCI_WIDTH_UINT32);
+          if (ret == PCIE_NO_MAPPING || (reg_value != 0xFFFFFFFF)) {
+            val_print(ACS_PRINT_ERR,
+                  "\n         Incorrect vendor ID 1 %04x    ", reg_value);
+            val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 02));
+            return;
+          }
+          /* Write command register offset of NF and verify no errors or exceptions occur */
+          val_pcie_enable_bme(nf_bdf);
+        }
+
+        /* 3.Make an unaligned 2 and 4 byte read to configuration space of RP and verify all 1’s returned. */
+        val_pcie_read_cfg_width(bdf, (TYPE01_VIDR + 1), &reg_value16, PCI_WIDTH_UINT16);
+        if (reg_value16 != 0xFFFF) {
+          val_print(ACS_PRINT_ERR, "\n       Incorrect vendor ID 2 %02x    ", reg_value16);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 03));
+          return;
+        }
+        val_pcie_read_cfg_width(bdf, (TYPE01_VIDR + 3), &reg_value, PCI_WIDTH_UINT32);
+        if (reg_value != 0xFFFFFFFF) {
+          val_print(ACS_PRINT_ERR, "\n       Incorrect vendor ID 3 %04x    ", reg_value);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 04));
+          return;
+        }
+
+        /* 4.Check device under RP support FLR */
+        /** Skip Check if there is an Ethernet or Display controller
+         * under the RP device, and this no device support FLR.**/
+        dev_bdf = check_bdf_under_rp(bdf);
+        if (dev_bdf == 0)
+        {
+          val_print(ACS_PRINT_DEBUG, "\n       There is no device support FLR for RP BDF 0x%x", bdf);
+          continue;
+        }
+        /* 5.Check RP support CSR */
+        val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
+        val_pcie_read_cfg_width(bdf, cap_base + ROOTCP_OFFSET, &reg_value, PCI_WIDTH_UINT16);
+        if ((reg_value & 0x01) != 0x01) {
+           val_print(ACS_PRINT_DEBUG,     "\n       RRS software visibility is not enabled on RP: 0x%x", bdf);
+           continue;
+        }
+
+        /* 6. Check device header type is type0 */
+        if (val_pcie_function_header_type(dev_bdf) != TYPE0_HEADER) {
+          val_print(ACS_PRINT_ERR, "\n       Device header type is not type0 for BDF  0x%x", dev_bdf);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 05));
+          return;
+        }
+
+        /* 7.Check device ecam acess when disable CSR and FLR */
+        //  Disable CRS software visibility in R
+        val_pcie_read_cfg_width(bdf, cap_base + RTCTRL_OFFSET, &reg_value, PCI_WIDTH_UINT16);
+        if ((reg_value & CSR_EN_SHIFT) == CSR_ENABLE) {
+          reg_value &= ~CSR_ENABLE;
+          val_pcie_write_cfg_width(bdf, cap_base + RTCTRL_OFFSET, &reg_value, PCI_WIDTH_UINT16);
+        }
+        // Set founction level reset for device D
+        val_pcie_find_capability(dev_bdf, PCIE_ECAP, ECID_AF, &af_cap_base);
+        val_pcie_read_cfg_width(dev_bdf, af_cap_base + AF_CTRL, &flr_reg, PCI_WIDTH_UINT8);
+        flr_reg |= FLR_EN;
+        val_pcie_write_cfg_width(dev_bdf, af_cap_base + AF_CTRL, &flr_reg, PCI_WIDTH_UINT8);
+        val_pcie_read_cfg_width(bdf, TYPE01_VIDR, &reg_value, PCI_WIDTH_UINT16);
+        if (reg_value != 0xFFFF) {
+          val_print(ACS_PRINT_ERR, "\n       Incorrect vendor ID %04x    ", reg_value);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 06));
+          return;
+        }
+        // Keep reading vendor ID till D is discovered
+        ret = wait_device_discovery(dev_bdf);
+        if (ret == 0) {
+          val_print(ACS_PRINT_ERR, "\n       Device re discover fail for BDF  0x%x", dev_bdf);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 06));
+          return;
+        }
+
+        /* 8.Check device ecam acess when enable CSR and FLR */
+        val_pcie_read_cfg_width(bdf, cap_base + RTCTRL_OFFSET, &reg_value, PCI_WIDTH_UINT16);
+        if ((reg_value & CSR_EN_SHIFT) != CSR_ENABLE) {
+          reg_value |= CSR_ENABLE;
+          val_pcie_write_cfg_width(bdf, cap_base + RTCTRL_OFFSET, &reg_value, PCI_WIDTH_UINT16);
+        }
+        // Set founction level reset for device D
+        val_pcie_read_cfg_width(dev_bdf, af_cap_base + AF_CTRL, &flr_reg, PCI_WIDTH_UINT8);
+        flr_reg |= FLR_EN;
+        val_pcie_write_cfg_width(dev_bdf, af_cap_base + AF_CTRL, &flr_reg, PCI_WIDTH_UINT8);
+        val_pcie_read_cfg_width(bdf, TYPE01_VIDR, &reg_value, PCI_WIDTH_UINT16);
+        if (reg_value != 0x0001) { // CSR status
+          val_print(ACS_PRINT_ERR, "\n       Incorrect vendor ID %04x    ", reg_value);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 7));
+          return;
+        }
+        val_pcie_read_cfg_width(bdf, TYPE01_VIDR + 2, &reg_value, PCI_WIDTH_UINT16);
+        if (reg_value != 0xFFFF) {
+          val_print(ACS_PRINT_ERR, "\n       Incorrect device ID %04x    ", reg_value);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 7));
+          return;
+        }
+        // Keep reading vendor ID till D is discovered
+        ret = wait_device_discovery(dev_bdf);
+        if (ret == 0) {
+          val_print(ACS_PRINT_ERR, "\n       Device re discover fail for BDF  0x%x", dev_bdf);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 11));
+          return;
+        }
+
+        /* 9. Check device ecam access when rp link down */
+        /* Disable rp link*/
+        val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
+        val_pcie_read_cfg(bdf, cap_base + LCTRLR_OFFSET, &reg_value);
+        if ((reg_value & LINK_DISABLE_SHIFT) != LINK_DISABLE) {
+          val_print(ACS_PRINT_ERR, "\n       Link control is not link disable and disable it", 0);
+          reg_value |= LINK_DISABLE;
+          val_pcie_write_cfg(bdf, cap_base + LCTRLR_OFFSET, reg_value);
+        }
+        val_pcie_read_cfg_width(bdf, TYPE01_VIDR, &reg_value, PCI_WIDTH_UINT16);
+        if (reg_value != 0xFFFF) {
+          val_print(ACS_PRINT_ERR, "\n       Incorrect vendor ID %04x    ", reg_value);
+          val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 12));
+          return;
+        }
+        /* Enable rp link*/
+        if ((reg_value & LINK_DISABLE_SHIFT) == LINK_DISABLE) {
+          val_print(ACS_PRINT_ERR, "\n       Link control is link disable and relink it", 0);
+          reg_value &= ~LINK_DISABLE;
+          val_pcie_write_cfg(bdf, cap_base + LCTRLR_OFFSET, reg_value);
+        }
+      }
+
+exception_return:
+      /*Write back original value */
+      /* Memory Space might have constraint on RW/RO behaviour
+        * So not checking for Read-Write Data mismatch.
+      */
+      if (IS_TEST_FAIL(val_get_status(hart_index))) {
+        val_print(ACS_PRINT_ERR,
+            "\n       Failed exception on Memory Access For Bdf : 0x%x", bdf);
+        val_pcie_clear_urd(bdf);
+        return;
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+        "\n       No RP type device found.", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p005_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p006.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p006.c
@@ -1,0 +1,250 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021, 2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_gic.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 6)
+#define TEST_RULE  "ME_MMS_010_010, ME_MMS_020_010"
+#define TEST_DESC  "Verify each host bridge has a memory range available for 64-bit BARs and 32-bit BARs"
+
+#define AML_DEVICE_OP_BYTE0     0x5B
+#define AML_DEVICE_OP_BYTE1     0x82
+#define AML_NAME_OP             0x08
+#define AML_END_TAG             0x79
+#define AML_QWORD_MEM_OP        0x8A
+#define AML_DWORD_MEM_OP        0x87
+#define AML_DWORD_MEM_BYTE_OP   0x01
+#define AML_CRS_BUFFER_OP       0x11
+
+#define PCIE_CRS_LEN            100
+#define CRS_MEM_FLAG_LEN        4
+
+#define MAX_MMIO_RANGE_NUM      10
+static uint8_t host_num;
+
+typedef struct {
+  uint32_t mem32_start;
+  uint32_t mem32_len;
+  uint64_t mem64_start;
+  uint64_t mem64_len;
+} pcie_mmio_range;
+
+pcie_mmio_range mmio_range[MAX_MMIO_RANGE_NUM] = {0};
+
+static
+uint8_t
+strncmp (char *str1, const char *str2, uint8_t len)
+{
+  if ((str1 == NULL) || (str2 == NULL) || (len == 0)) {
+    return 1;
+  }
+
+  while ((len > 1) && (*str1 != '\0') && (*str2 != '\0') && (*str1 == *str2)) {
+    str1++;
+    str2++;
+    len--;
+  }
+
+  return *str1 - *str2;
+}
+
+
+uint32_t parse_pkg_length(uint8_t **pkg) {
+    uint8_t *ptr = *pkg;
+    uint32_t length = 0;
+    
+    if ((*ptr & 0xC0) == 0x00) { // 1 byte length
+        length = *ptr & 0x3F;
+        ptr += 1;
+    } else if ((*ptr & 0xC0) == 0x40) { // 2 byte length
+        length = (ptr[1] << 4) | (ptr[0] & 0x0F);
+        ptr += 2;
+    } else if ((*ptr & 0xC0) == 0x80) { // 3 byte length
+        length = (ptr[2]  << 12) | (ptr[1] << 4) | (ptr[0] & 0x0F);
+        ptr += 3;
+    }
+    
+    *pkg = ptr;
+    return length;
+}
+
+static
+void 
+parse_crs(uint8_t *crs_start, uint8_t *crs_end) {
+  uint8_t *ptr = crs_start;
+  uint32_t offset = 0;
+  uint8_t find_mem64, find_mem32;
+  uint8_t range_count = host_num;
+
+  find_mem64 = 0;
+  find_mem32 = 0;
+  while ((ptr < crs_end) && (*ptr != AML_END_TAG)) {
+      switch (*ptr) {
+          case AML_QWORD_MEM_OP:  // 64-bit memory
+              // val_print(ACS_PRINT_INFO, "qword mem ptr = 0x%llx\n", (uint64_t)(ptr));
+              // Skip OP + LEN + Flags + offset, 14 bytes
+              offset = 1 + 1 + CRS_MEM_FLAG_LEN + sizeof(uint64_t);
+              mmio_range[range_count].mem64_start = *(uint64_t*)(ptr + offset);
+              offset += 24;
+              mmio_range[range_count].mem64_len = *(uint64_t*)(ptr + offset);
+              ptr += 0x2B;  // qword mem len
+              find_mem64 = 1;
+              break;
+
+          case AML_DWORD_MEM_OP:  // 32-bit memory
+              offset = 1 + 1 + 3; // Skip OP + LEN + Flags - 1, 5 bytes
+              if (*(ptr + offset) != AML_DWORD_MEM_BYTE_OP) {
+                ptr += offset;
+                break;
+              }
+              // val_print(ACS_PRINT_INFO, "dword mem ptr = 0x%llx\n", (uint64_t)(ptr));
+              // Skip OP + LEN + Flags + offset, 10 bytes
+              offset = 1 + 1 + CRS_MEM_FLAG_LEN + sizeof(uint32_t);
+              mmio_range[range_count].mem32_start = *(uint32_t*)(ptr + offset);
+              offset += 12;
+              mmio_range[range_count].mem32_len = *(uint32_t*)(ptr + offset);
+              ptr += 0x17; // dword mem len
+              find_mem32 = 1;
+              break;
+
+          default:
+              ptr += 1;
+              break;
+      }
+  }
+  // 打印结果
+  for (int i = 0; i < host_num + 1; i++) {
+      val_print(ACS_PRINT_INFO, "mem64_start = 0x%llx\n", mmio_range[i].mem64_start);
+      val_print(ACS_PRINT_INFO, "mem64_len = 0x%llx\n", mmio_range[i].mem64_len);
+      val_print(ACS_PRINT_INFO, "mem32_start = 0x%llx\n", mmio_range[i].mem32_start);
+      val_print(ACS_PRINT_INFO, "mem32_len = 0x%llx\n", mmio_range[i].mem32_len);
+  }
+}
+
+static
+uint8_t
+find_pci_host_bridges (uint64_t ptr)
+{
+  uint32_t table_length;
+  uint32_t pkg_length;
+  uint8_t *aml_start;
+  uint8_t *cur_ptr;
+  uint8_t *device_end;
+  uint32_t buf_len;
+
+  host_num = 0;
+
+  table_length = *(uint32_t *)(ptr + 4);
+  aml_start = (uint8_t *)(ptr);  // skip common header
+  val_print(ACS_PRINT_INFO, "dsdt table length = 0x%x\n", table_length);
+  while (aml_start < (uint8_t *)(ptr + table_length)){
+    if ((*aml_start == AML_DEVICE_OP_BYTE0) && (*(aml_start + 1) == AML_DEVICE_OP_BYTE1)) {
+      cur_ptr = aml_start + 2;
+      pkg_length = parse_pkg_length(&cur_ptr);
+      // val_print(ACS_PRINT_INFO, "current ptr = 0x%llx\n", (uint64_t)cur_ptr);
+      // val_print(ACS_PRINT_INFO, "dsdt device pkg length = 0x%x\n", pkg_length);
+      if (strncmp((char *)(cur_ptr), "PCI", 3) == 0) {
+          // find _crs
+          val_print(ACS_PRINT_INFO, "Find PCIe host bridge %d\n", host_num);
+          device_end = cur_ptr + pkg_length;
+          cur_ptr += 4; // skip "PCIx"
+          while (cur_ptr < device_end) {
+            if ((strncmp((char *)cur_ptr, "_CRS", 4) == 0) && (*(cur_ptr + 4) == AML_CRS_BUFFER_OP)) {
+                // val_print(ACS_PRINT_INFO, "Find _CRS: 0x%lx\n", (uint64_t)cur_ptr);
+                cur_ptr += 5;    // skip "_CRS" and AML_BUFFER_OP
+                buf_len = parse_pkg_length(&cur_ptr);
+                // val_print(ACS_PRINT_INFO, "_CRS buf len: 0x%lx\n", buf_len);
+                if (buf_len > PCIE_CRS_LEN) {
+                  parse_crs(cur_ptr, cur_ptr + buf_len);
+                }
+                cur_ptr += buf_len;
+            } else {
+              cur_ptr++;
+            }
+          }
+          host_num += 1;
+      }
+      aml_start += pkg_length;
+    } else {
+      aml_start += 1;
+    }
+  }
+
+  return 0;
+}
+
+
+static
+void
+payload(void)
+{
+  uint32_t hart_index;
+  uint32_t test_skip = 1;
+  uint64_t dsdt_ptr;
+  uint32_t index;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  dsdt_ptr = val_pcie_get_info(PCIE_INFO_DSDT_PTR, 0);
+  if (dsdt_ptr != 0) {
+    val_print(ACS_PRINT_INFO, "dsdt_ptr = 0x%llx\n", dsdt_ptr);
+    find_pci_host_bridges(dsdt_ptr);
+  }
+
+  if (host_num != 0) {
+    test_skip = 0;
+    val_print(ACS_PRINT_INFO, "host_num = %d\n", host_num);
+    for (index = 0; index < host_num; index++) {
+      if ((mmio_range[index].mem64_len == 0) || (mmio_range[index].mem32_len == 0)) {
+        val_print(ACS_PRINT_ERR, "\n       PCIe Host Bridge have invalid mem64 or mem32", 0);
+        val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+      }
+    }
+  }
+
+  if (test_skip == 1) {
+    val_print(ACS_PRINT_ERR, "\n       No Host Bridge in DSDT", 0);
+    val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p006_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p007.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p007.c
@@ -1,0 +1,272 @@
+/** @file
+ * Copyright (c) 2021, 2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 7)
+#define TEST_RULE  "MF_MMS_040_010, MF_MMS_050_010"
+#define TEST_DESC  "Check all 1's for accesses memory outside the PCIe bus range or when the link is down..."
+
+static void *branch_to_test;
+
+static
+void
+esr(uint64_t interrupt_type, void *context)
+{
+  uint32_t hart_index;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Update the ELR to return to test specified address */
+  val_hart_update_elr(context, (uint64_t)branch_to_test);
+
+  val_print(ACS_PRINT_ERR, "\n       Received exception of type: %d", interrupt_type);
+  val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+}
+
+static
+uint32_t
+check_bdf_under_rp(uint32_t rp_bdf)
+{
+
+  uint32_t reg_value;
+  uint32_t rp_sec_bus, rp_sub_bus;
+  uint32_t dev_bdf, dev_bus, dev_sec_bus;
+  uint32_t rp_seg, dev_seg;
+  uint32_t base_cc;
+  uint32_t dev_num, func_num;
+
+  rp_seg = PCIE_EXTRACT_BDF_SEG(rp_bdf);
+  val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
+  rp_sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
+  rp_sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+
+  for (dev_sec_bus = rp_sec_bus; dev_sec_bus <= rp_sub_bus; dev_sec_bus++)
+  {
+      for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
+      {
+          for (func_num = 0; func_num < PCIE_MAX_FUNC; func_num++)
+          {
+              dev_bdf = PCIE_CREATE_BDF(rp_seg, dev_sec_bus, dev_num, func_num);
+              val_pcie_read_cfg(dev_bdf, TYPE01_VIDR, &reg_value);
+              if (reg_value == PCIE_UNKNOWN_RESPONSE)
+                  continue;
+
+              dev_bus = PCIE_EXTRACT_BDF_BUS(dev_bdf);
+              dev_seg = PCIE_EXTRACT_BDF_SEG(dev_bdf);
+              if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
+              {
+                  val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
+                  val_print(ACS_PRINT_DEBUG, "\n       Class code is 0x%x", reg_value);
+                  base_cc = reg_value >> TYPE01_BCC_SHIFT;
+                  if ((base_cc != CNTRL_CC) && (base_cc != DP_CNTRL_CC) && (base_cc != MAS_CC)) {
+                    return 1;
+                  }
+              }
+           }
+       }
+  }
+
+   return 0;
+}
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t hart_index;
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t tbl_index;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t status;
+  uint32_t test_skip = 1;
+  uint64_t mem_base = 0, ori_mem_base = 0;
+  uint64_t mem_lim = 0, new_mem_lim;
+  uint32_t mem_offset = 0;
+  uint32_t reg_value, value;
+  uint32_t cap_base = 0;
+  uint8_t ret = 0;
+
+  tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Install sync and async handlers to handle exceptions.*/
+  status = val_hart_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
+  status |= val_hart_install_esr(EXCEPT_AARCH64_SERROR, esr);
+  if (status)
+  {
+      val_print(ACS_PRINT_ERR, "\n       Failed in installing the exception handler", 0);
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+      return;
+  }
+
+  branch_to_test = &&exception_return;
+
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RP) {
+        /** Skip Check if there is an Ethernet or Display controller
+         * under the RP device.**/
+        ret = check_bdf_under_rp(bdf);
+        if (ret == 0) {
+          val_print(ACS_PRINT_DEBUG, "\n       Skipping for RP BDF 0x%x", bdf);
+          continue;
+        }
+
+        /* Enable Bus Master Enable */
+        val_pcie_enable_bme(bdf);
+        /* Enable Memory Space Access */
+        val_pcie_enable_msa(bdf);
+        /* Clearing UR in Device Status Register */
+        val_pcie_clear_urd(bdf);
+        val_print(ACS_PRINT_DEBUG, "\n       BDF is 0x%x", bdf);
+
+        /* 
+         * Check When Address is outside the Range of NP Memory Range.
+        */
+        /* Read Function's Memory Base Limit Register */
+        val_pcie_read_cfg(bdf, TYPE1_NP_MEM, &reg_value);
+        if (reg_value == 0)
+          continue;
+        mem_base = (reg_value & MEM_BA_MASK) << MEM_BA_SHIFT;
+        mem_lim = (reg_value & MEM_LIM_MASK) | MEM_LIM_LOWER_BITS;
+        val_print(ACS_PRINT_DEBUG, "\n       Memory base is 0x%llx", mem_base);
+        val_print(ACS_PRINT_DEBUG, " Memory lim is  0x%llx", mem_lim);
+        /* If Memory Limit is programmed with value less the Base, then Skip.*/
+        if (mem_lim < mem_base) {
+          val_print(ACS_PRINT_DEBUG, "\n       No NP memory on secondary side of the Bridge", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       Skipping Bdf - 0x%x", bdf);
+          continue;
+        }
+
+        /* If test runs for atleast an endpoint */
+        test_skip = 0;
+        mem_offset = val_pcie_mem_get_offset(bdf, NON_PREFETCH_MEMORY);
+        if ((mem_base + mem_offset) > mem_lim)
+        {
+            val_print(ACS_PRINT_ERR,
+                    "\n       Memory offset + base 0x%llx", mem_base + mem_offset);
+            val_print(ACS_PRINT_ERR, " exceeds the memory limit 0x%llx", mem_lim);
+            val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 02));
+            return;
+        }
+
+        /**Check_1: Accessing out of NP memory limit range must return 0xFFFFFFFF
+         * If the limit exceeds 1MB then modify the range to be 1MB
+         * and access out of the limit set
+         **/
+        ori_mem_base = mem_base;
+        if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
+        {
+           val_print(ACS_PRINT_DEBUG, "\n       Entered Check_1 for bdf 0x%x", bdf);
+           new_mem_lim = mem_base + MEM_OFFSET_LARGE;
+           mem_base = mem_base | (mem_base  >> 16);
+           val_pcie_write_cfg(bdf, TYPE1_NP_MEM, mem_base);
+           val_pcie_read_cfg(bdf, TYPE1_NP_MEM, &reg_value);
+
+           val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
+           val_print(ACS_PRINT_DEBUG, "  Value read is 0x%llx", value);
+           if (value != PCIE_UNKNOWN_RESPONSE)
+           {
+               val_print(ACS_PRINT_ERR, "\n       Memory range for bdf 0x%x", bdf);
+               val_print(ACS_PRINT_ERR, " is 0x%x", reg_value);
+               val_print(ACS_PRINT_ERR,
+                       "\n       Out of range 0x%x", (new_mem_lim + MEM_OFFSET_SMALL));
+               val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 03));
+           }
+
+           /* Check_2 device bar access when rp link down */
+           /* Disable rp link*/
+          val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
+          val_pcie_read_cfg(bdf, cap_base + LCTRLR_OFFSET, &reg_value);
+          if ((reg_value & LINK_DISABLE_SHIFT) != LINK_DISABLE) {
+            val_print(ACS_PRINT_ERR, "\n       Link control is not link disable and disable it", 0);
+            reg_value |= LINK_DISABLE;
+            val_pcie_write_cfg(bdf, cap_base + LCTRLR_OFFSET, reg_value);
+            val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
+            val_print(ACS_PRINT_DEBUG, "\n Check_2 Value read is 0x%llx", value);
+            if (value != PCIE_UNKNOWN_RESPONSE)
+            {
+                val_print(ACS_PRINT_ERR, "\n  Check_2 Memory range for bdf 0x%x", bdf);
+                val_print(ACS_PRINT_ERR, " is 0x%x", reg_value);
+                val_print(ACS_PRINT_ERR,
+                        "\n       Out of range 0x%x", (new_mem_lim + MEM_OFFSET_SMALL));
+                val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 03));
+            }
+          }
+        }
+
+exception_return:
+        /*Write back original value */
+        if ((mem_lim >> MEM_SHIFT) > (ori_mem_base >> MEM_SHIFT))
+        {
+            val_pcie_write_cfg(bdf, TYPE1_P_MEM,
+                                              ((mem_lim & MEM_LIM_MASK) | (ori_mem_base  >> 16)));
+            val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_lim >> 32));
+        }
+
+        /* Memory Space might have constraint on RW/RO behaviour
+         * So not checking for Read-Write Data mismatch.
+        */
+        if (IS_TEST_FAIL(val_get_status(hart_index))) {
+          val_print(ACS_PRINT_ERR,
+              "\n       Failed exception on Memory Access For Bdf : 0x%x", bdf);
+          val_pcie_clear_urd(bdf);
+          return;
+        }
+     }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+        "\n       No RP type device for test found ", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p007_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from single HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p008.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p008.c
@@ -1,0 +1,306 @@
+/** @file
+ * Copyright (c) 2021, 2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 8)
+#define TEST_RULE  "MF_MMS_040_010, MF_MMS_050_010"
+#define TEST_DESC  "Check all 1's for accesses prefetchable memory outside the PCIe bus range or when the link is down..."
+
+static void *branch_to_test;
+
+static
+void
+esr(uint64_t interrupt_type, void *context)
+{
+  uint32_t hart_index;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Update the ELR to return to test specified address */
+  val_hart_update_elr(context, (uint64_t)branch_to_test);
+
+  val_print(ACS_PRINT_ERR, "\n       Received exception of type: %d", interrupt_type);
+  val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+}
+
+static
+uint32_t
+check_bdf_under_rp(uint32_t rp_bdf)
+{
+
+  uint32_t reg_value;
+  uint32_t rp_sec_bus, rp_sub_bus;
+  uint32_t dev_bdf, dev_bus, dev_sec_bus;
+  uint32_t rp_seg, dev_seg;
+  uint32_t base_cc;
+  uint32_t dev_num, func_num;
+
+  rp_seg = PCIE_EXTRACT_BDF_SEG(rp_bdf);
+  val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
+  rp_sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
+  rp_sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
+
+  for (dev_sec_bus = rp_sec_bus; dev_sec_bus <= rp_sub_bus; dev_sec_bus++)
+  {
+      for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
+      {
+          for (func_num = 0; func_num < PCIE_MAX_FUNC; func_num++)
+          {
+              dev_bdf = PCIE_CREATE_BDF(rp_seg, dev_sec_bus, dev_num, func_num);
+              val_pcie_read_cfg(dev_bdf, TYPE01_VIDR, &reg_value);
+              if (reg_value == PCIE_UNKNOWN_RESPONSE)
+                  continue;
+
+              dev_bus = PCIE_EXTRACT_BDF_BUS(dev_bdf);
+              dev_seg = PCIE_EXTRACT_BDF_SEG(dev_bdf);
+              if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
+              {
+                  val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
+                  val_print(ACS_PRINT_DEBUG, "\n       Class code is 0x%x", reg_value);
+                  base_cc = reg_value >> TYPE01_BCC_SHIFT;
+                  if ((base_cc != CNTRL_CC) && (base_cc != DP_CNTRL_CC) && (base_cc != MAS_CC)) {
+                    return 1;
+                  }
+              }
+           }
+       }
+  }
+
+   return 0;
+}
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t hart_index;
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t tbl_index;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t status;
+  uint32_t test_skip = 1;
+  uint64_t mem_base = 0, mem_base_upper = 0, ori_mem_base = 0;
+  uint64_t mem_lim = 0, mem_lim_upper = 0, new_mem_lim;
+  uint64_t updated_mem_base = 0, updated_mem_lim = 0;
+  uint32_t reg_value, value, new_value;
+  uint32_t cap_base = 0;
+  uint32_t mem_offset = 0;
+  uint8_t ret = 0;
+
+  tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  /* Install sync and async handlers to handle exceptions.*/
+  status = val_hart_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
+  status |= val_hart_install_esr(EXCEPT_AARCH64_SERROR, esr);
+  if (status)
+  {
+      val_print(ACS_PRINT_ERR, "\n       Failed in installing the exception handler", 0);
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 01));
+      return;
+  }
+
+  branch_to_test = &&exception_return;
+
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RP) {
+        /** Skip Check if there is an Ethernet or Display controller
+         * under the RP device.**/
+        ret = check_bdf_under_rp(bdf);
+        if (ret == 0) {
+          val_print(ACS_PRINT_DEBUG, "\n       Skipping for RP BDF 0x%x", bdf);
+          continue;
+        }
+
+        /* Enable Bus Master Enable */
+        val_pcie_enable_bme(bdf);
+        /* Enable Memory Space Access */
+        val_pcie_enable_msa(bdf);
+        /* Clearing UR in Device Status Register */
+        val_pcie_clear_urd(bdf);
+        val_print(ACS_PRINT_DEBUG, "\n       BDF is 0x%x", bdf);
+
+        /* 
+         * Check When Address is outside the Range of Prefetchable Memory Range.
+        */
+        /* Read Function's Memory Base Limit Register */
+        val_pcie_read_cfg(bdf, TYPE1_P_MEM, &reg_value);
+        if (reg_value == 0)
+          continue;
+        mem_base = (reg_value & MEM_BA_MASK) << MEM_BA_SHIFT;
+        mem_lim = (reg_value & MEM_LIM_MASK) | MEM_LIM_LOWER_BITS;
+        /* If 64 Bit Prefetchable Address */
+        if ((reg_value & P_MEM_PAC_MASK) == 0x1) {
+          val_pcie_read_cfg(bdf, TYPE1_P_MEM_BU, &reg_value);
+          mem_base_upper = reg_value;
+          val_pcie_read_cfg(bdf, TYPE1_P_MEM_LU, &reg_value);
+          mem_lim_upper = reg_value;
+        }
+
+        mem_base |= (mem_base_upper << P_MEM_BU_SHIFT);
+        mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
+        val_print(ACS_PRINT_DEBUG, "\n       Memory base is 0x%llx", mem_base);
+        val_print(ACS_PRINT_DEBUG, " Memory lim is  0x%llx", mem_lim);
+        /* If Memory Limit is programmed with value less the Base, then Skip.*/
+        if (mem_lim < mem_base) {
+          val_print(ACS_PRINT_DEBUG, "\n       No Prefetchable memory on secondary side of the Bridge", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       Skipping Bdf - 0x%x", bdf);
+          continue;
+        }
+
+        /* If test runs for atleast an endpoint */
+        test_skip = 0;
+        mem_offset = val_pcie_mem_get_offset(bdf, PREFETCH_MEMORY);
+
+        if ((mem_base + mem_offset) > mem_lim)
+        {
+            val_print(ACS_PRINT_ERR,
+                    "\n        Memory offset + base 0x%llx", mem_base + mem_offset);
+            val_print(ACS_PRINT_ERR, " exceeds the memory limit 0x%llx", mem_lim);
+            val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 02));
+            return;
+        }
+
+        /**Check_1: Accessing out of Prefetchable memory limit range must return 0xFFFFFFFF
+         * If the limit exceeds 1MB then modify the range to be 1MB
+         * and access out of the limit set
+         **/
+        ori_mem_base = mem_base;
+        if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
+        {
+           val_print(ACS_PRINT_DEBUG, "\n       Entered Check_1 for bdf 0x%x", bdf);
+           new_mem_lim  = mem_base + MEM_OFFSET_LARGE;
+           val_pcie_read_cfg(bdf, TYPE1_P_MEM, &new_value);
+
+          if ((new_value & P_MEM_PAC_MASK) == 0x1)
+               val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_base >> 32));
+
+           mem_base = ((uint32_t)mem_base) | ((uint32_t)mem_base >> 16);
+           val_print(ACS_PRINT_INFO, "       mem_base new is 0x%llx", mem_base);
+           val_pcie_write_cfg(bdf, TYPE1_P_MEM, mem_base);
+
+           val_pcie_read_cfg(bdf, TYPE1_P_MEM, &reg_value);
+           updated_mem_base = (reg_value & MEM_BA_MASK) << MEM_BA_SHIFT;
+           updated_mem_lim = (reg_value & MEM_LIM_MASK) | MEM_LIM_LOWER_BITS;
+
+           /* If 64 Bit Prefetchable Address */
+           if ((reg_value & P_MEM_PAC_MASK) == 0x1) {
+             val_pcie_read_cfg(bdf, TYPE1_P_MEM_BU, &reg_value);
+             mem_base_upper = reg_value;
+             val_pcie_read_cfg(bdf, TYPE1_P_MEM_LU, &reg_value);
+             mem_lim_upper = reg_value;
+           }
+
+           updated_mem_base |= (mem_base_upper << P_MEM_BU_SHIFT);
+           updated_mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
+
+           val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
+           val_print(ACS_PRINT_DEBUG, "       Value read is 0x%llx", value);
+           if (value != PCIE_UNKNOWN_RESPONSE)
+           {
+               val_print(ACS_PRINT_ERR, "\n       Memory range for bdf 0x%x", bdf);
+               val_print(ACS_PRINT_ERR, " is 0x%llx", updated_mem_base);
+               val_print(ACS_PRINT_ERR, " 0x%llx", updated_mem_lim);
+               val_print(ACS_PRINT_ERR,
+                   "\n       Out of range 0x%llx", (new_mem_lim + MEM_OFFSET_SMALL));
+               val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 03));
+           }
+
+           /* Check_2 device bar access when rp link down */
+           /* Disable rp link*/
+          val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);
+          val_pcie_read_cfg(bdf, cap_base + LCTRLR_OFFSET, &reg_value);
+          if ((reg_value & LINK_DISABLE_SHIFT) != LINK_DISABLE) {
+            val_print(ACS_PRINT_ERR, "\n       Link control is not link disable and disable it", 0);
+            reg_value |= LINK_DISABLE;
+            val_pcie_write_cfg(bdf, cap_base + LCTRLR_OFFSET, reg_value);
+            val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
+            val_print(ACS_PRINT_DEBUG, "\n       Value read is 0x%llx", value);
+            if (value != PCIE_UNKNOWN_RESPONSE)
+            {
+                val_print(ACS_PRINT_ERR, "\n       Memory range for bdf 0x%x", bdf);
+                val_print(ACS_PRINT_ERR, " is 0x%llx", updated_mem_base);
+                val_print(ACS_PRINT_ERR, " 0x%llx", updated_mem_lim);
+                val_print(ACS_PRINT_ERR,
+                    "\n       Out of range 0x%llx", (new_mem_lim + MEM_OFFSET_SMALL));
+                val_set_status(hart_index, RESULT_FAIL(TEST_NUM, 03));
+            }
+          }
+        }
+
+exception_return:
+        /*Write back original value */
+        if ((mem_lim >> MEM_SHIFT) > (ori_mem_base >> MEM_SHIFT))
+        {
+            val_pcie_write_cfg(bdf, TYPE1_P_MEM,
+                                              ((mem_lim & MEM_LIM_MASK) | (ori_mem_base  >> 16)));
+            val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_lim >> 32));
+        }
+
+        /* Memory Space might have constraint on RW/RO behaviour
+         * So not checking for Read-Write Data mismatch.
+        */
+        if (IS_TEST_FAIL(val_get_status(hart_index))) {
+          val_print(ACS_PRINT_ERR,
+              "\n       Failed exception on Memory Access For Bdf : 0x%x", bdf);
+          val_pcie_clear_urd(bdf);
+          return;
+        }
+     }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+        "\n       No RP type device for test found.", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p008_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from single HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p009.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p009.c
@@ -1,0 +1,117 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 9)
+#define TEST_RULE  "ME_MMS_080_010"
+#define TEST_DESC  "Check EA Capability                   "
+
+static
+void
+payload(void)
+{
+
+  uint64_t num_ecam;
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t reg_value;
+  uint32_t enable_value;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  uint32_t cap_base;
+  uint32_t status;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  tbl_index = 0;
+  test_fails = 0;
+
+  num_ecam = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
+
+  if (num_ecam == 0) {
+      val_print(ACS_PRINT_ERR, "\n       No ECAMs discovered              ", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 01));
+      return;
+  }
+
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+      if (dp_type == RP) {
+        /* If test runs for atleast an root port */
+        test_skip = 0;
+
+        /* Retrieve the addr of Enhanced Allocation capability (14h) and check if the
+        * capability structure is not supported.
+        */
+        status = val_pcie_find_capability(bdf, PCIE_CAP, CID_EA, &cap_base);
+        if (status == PCIE_CAP_NOT_FOUND)
+            continue;
+
+        /* Read Entry type register(08h) present in Enhanced Allocation capability struct(10h) */
+        val_pcie_read_cfg(bdf, cap_base + EA_ENTRY_TYPE_OFFSET, &reg_value);
+
+        /* Extract enable value */
+        enable_value = (reg_value >> EA_ENTRY_TYPE_ENABLE_SHIFT) & EA_ENTRY_TYPE_ENABLE_MASK;
+        if (enable_value)
+        {
+            val_print(ACS_PRINT_ERR, "\n       Failed. BDF 0x%x Supports Enhanced Allocation", bdf);
+            test_fails++;
+        }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+               "\n       Found no Endpoint with PCIe Capability. Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 01));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 01));
+}
+
+uint32_t
+os_p009_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p010.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p010.c
@@ -1,0 +1,125 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 10)
+#define TEST_RULE  "ME_ACS_010_010"
+#define TEST_DESC  "Check RP support ACS......"
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  uint32_t acs_data;
+  uint32_t data;
+  uint32_t curr_bdf_failed = 0;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP */
+      if (dp_type == RP)
+      {
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Read the ACS Capability */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR,
+                    "\n       ACS Capability not supported, Bdf : 0x%x", bdf);
+              test_fails++;
+              continue;
+          }
+
+          val_pcie_read_cfg(bdf, cap_base + ACSCR_OFFSET, &acs_data);
+
+          /* Extract ACS source validation bit */
+          data = VAL_EXTRACT_BITS(acs_data, 0, 0);
+          if (data == 0) {
+              val_print(ACS_PRINT_DEBUG,
+                    "\n       Source validation not supported, Bdf : 0x%x", bdf);
+              curr_bdf_failed++;
+          }
+          /* Extract ACS translation blocking bit */
+          data = VAL_EXTRACT_BITS(acs_data, 1, 1);
+          if (data == 0) {
+              val_print(ACS_PRINT_DEBUG,
+                    "\n       Translation blocking not supported, Bdf : 0x%x", bdf);
+              curr_bdf_failed++;
+          }
+
+          if (curr_bdf_failed > 0) {
+              val_print(ACS_PRINT_ERR,
+                    "\n       ACS Capability Check Failed, Bdf : 0x%x", bdf);
+              curr_bdf_failed = 0;
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device found. Skipping device", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p010_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p011.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p011.c
@@ -1,0 +1,167 @@
+/** @file
+ * Copyright (c) 2020-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 11)
+#define TEST_RULE  "ME_ACS_020_010"
+#define TEST_DESC  "Check RP support Enhanced ACS......"
+
+static
+uint8_t
+check_pcie_rp_has_bar(uint32_t bdf)
+{
+  uint32_t index;
+  uint32_t bar_low32bits = 0;
+  uint32_t bar_high32bits = 0;
+  uint64_t bar[TYPE1_MAX_BARS];
+
+  index = 0;
+  while (index < TYPE1_MAX_BARS)
+  {
+    /* Read the base address register at loop index */
+    val_pcie_read_cfg(bdf, TYPE01_BAR + index * 4, &bar_low32bits);
+    /* Check if the BAR is Memory Mapped IO type */
+    if (((bar_low32bits >> BAR_MIT_SHIFT) & BAR_MIT_MASK) == MMIO)
+    {
+        /* Check if the BAR is 64-bit decodable */
+        if (((bar_low32bits >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_64)
+        {
+            /* Read the second sequential BAR at next index */
+            val_pcie_read_cfg(bdf, TYPE01_BAR + (index + 1) * 4, &bar_high32bits);
+
+            /* Fill upper 32-bits of 64-bit address with second sequential BAR */
+            bar[index] = ((uint64_t)bar_high32bits << 32) | (((bar_low32bits >> (BAR_BASE_SHIFT) & BAR_BASE_MASK)) << BAR_BASE_SHIFT);
+
+            /* Adjust the index to skip next sequential BAR */
+            index++;
+
+        } else if (((bar_low32bits >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_32)
+        {
+          /* Fill lower 32-bits of 64-bit address with first sequential BAR */
+          bar[index] = ((bar_low32bits >> (BAR_BASE_SHIFT) & BAR_BASE_MASK)) << BAR_BASE_SHIFT;
+        }
+
+        return 1;
+    }
+
+    /* Adjust index to point to next BAR */
+    index++;
+  }
+
+  return 0;
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  uint32_t acs_data;
+  uint32_t data;
+  uint32_t curr_bdf_failed = 0;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP */
+      if (dp_type == RP)
+      {
+          if (check_pcie_rp_has_bar(bdf) == 0) {
+            val_print(ACS_PRINT_DEBUG, "\n       RP (BDF:0x%x) does not have MMIO BAR. Skipping test", bdf);
+            continue;
+          }
+          
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Read the ACS Capability */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR,
+                    "\n       ACS Capability not supported, Bdf : 0x%x", bdf);
+              test_fails++;
+              continue;
+          }
+
+          val_pcie_read_cfg(bdf, cap_base + ACSCR_OFFSET, &acs_data);
+
+          /* Extract ACS Enhanced Capability bit */
+          data = VAL_EXTRACT_BITS(acs_data, 7, 7);
+          if (data == 0) {
+              val_print(ACS_PRINT_DEBUG,
+                    "\n       Enhanced Capability not supported, Bdf : 0x%x", bdf);
+              curr_bdf_failed++;
+          }
+
+          if (curr_bdf_failed > 0) {
+              val_print(ACS_PRINT_ERR,
+                    "\n       Enhanced ACS Capability Check Failed, Bdf : 0x%x", bdf);
+              curr_bdf_failed = 0;
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device which support bar found. Skipping device", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p011_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p012.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p012.c
@@ -1,0 +1,114 @@
+/** @file
+ * Copyright (c) 2020-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 12)
+#define TEST_RULE  "ME_MSI_010_010"
+#define TEST_DESC  "Check MSI support for PCIe RP and RCiEP......"
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  uint32_t int_pin;
+  uint32_t reg_value;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP or RCiEP */
+      if ((dp_type == RP) || (dp_type == RCiEP))
+      {
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+          val_pcie_read_cfg(bdf, TYPE01_ILR, &reg_value);
+          int_pin = VAL_EXTRACT_BITS(reg_value, TYPE01_IPR_SHIFT, TYPE01_IPR_SHIFT + 7);
+          val_print(ACS_PRINT_DEBUG, " int pin value %d", int_pin);
+
+          if (dp_type == RP) {
+            /* Check for MSI/MSI-X support */ 
+            val_print(ACS_PRINT_DEBUG, " MSI cap %d",
+                                      val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base));
+            val_print(ACS_PRINT_DEBUG, " MSIX cap %d",
+                                    val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base));
+
+            /* If MSI or MSI-X not supported, or INTx supported test fails */
+            if ((val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base) == PCIE_CAP_NOT_FOUND)
+              && (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base) == PCIE_CAP_NOT_FOUND)) {
+              val_print(ACS_PRINT_ERR, "\n       MSI/MSI-X not supported", 0);
+              test_fails++;
+            }
+          }
+          if (((int_pin >= 1) && (int_pin <= 4))) {
+            val_print(ACS_PRINT_ERR, "\n       INTx supported, INTX Pin Reg value not zero\n", 0);
+            test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP or RCiEP found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p012_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p013.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p013.c
@@ -1,0 +1,94 @@
+/** @file
+ * Copyright (c) 2020-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 13)
+#define TEST_RULE  "OE_PTM_010_010"
+#define TEST_DESC  "Check PTM support for PCIe RP......"
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP */
+      if (dp_type == RP)
+      {
+          /* Check for PTM support */ 
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_PTM, &cap_base) == PCIE_CAP_NOT_FOUND) {
+            val_print(ACS_PRINT_ERR, "\n       PTM not supported, skip device", 0);
+            continue;
+          }
+
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x support PTM cap", bdf);
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP support PTM found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 0));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p013_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p014.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p014.c
@@ -1,0 +1,96 @@
+/** @file
+ * Copyright (c) 2020-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 14)
+#define TEST_RULE  "ME_AER_010_010"
+#define TEST_DESC  "Check RP Adv Error Report......"
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP */
+      if (dp_type == RP)
+      {
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* If AER Not Supported, Fail. */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: AER Cap unsupported", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p014_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p015.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p015.c
@@ -1,0 +1,96 @@
+/** @file
+ * Copyright (c) 2020-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 15)
+#define TEST_RULE  "ME_AER_020_010"
+#define TEST_DESC  "Check RP DPC capability......"
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP */
+      if (dp_type == RP)
+      {
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* If DPC Not Supported, Fail. */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_DPC, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: DPC Cap unsupported", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p015_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p016.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p016.c
@@ -1,0 +1,112 @@
+/** @file
+ * Copyright (c) 2020-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 16)
+#define TEST_RULE  "ME_AER_030_010"
+#define TEST_DESC  "Check RP Extensions for DPC......"
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t reg_value;
+  uint32_t status;
+  uint32_t dpc_supported;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RP */
+      if (dp_type == RP)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Retrieve the addr of Downstream Port Containment (1Dh) and check if the
+          * capability structure is supported.
+          */
+          status = val_pcie_find_capability(bdf, PCIE_ECAP, ECID_DPC, &cap_base);
+          if (status == PCIE_CAP_NOT_FOUND)
+              continue;
+
+          /* If test runs for atleast one Rootport */
+          test_skip = 0;
+
+          /* Read DPC Capability Register(04h) present in Downstream Port Containment struct(1Dh)*/
+          val_pcie_read_cfg(bdf, cap_base + DPC_CTRL_OFFSET, &reg_value);
+          /* Extract 'RP Extensions for DPC' value */
+          dpc_supported = (reg_value >> DPC_RP_EXT_OFFSET) & DPC_RP_EXT_MASK;
+
+          /* If Extensions for DPC Not Supported, Fail. */
+          if (dpc_supported != 1) {
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: Extensions for DPC unsupported", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device support DPC cap found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p016_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p017.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p017.c
@@ -1,0 +1,93 @@
+/** @file
+ * Copyright (c) 2020,2021 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 17)
+#define TEST_RULE  "OE_AER_040_010"
+#define TEST_DESC  "Check RCiEP Adv Error Report......"
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP */
+      if (dp_type == RCiEP)
+      {
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+
+          /* If AER Not Supported, Fail. */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS) {
+            val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: AER Cap unsupported", bdf);
+          } else {
+            val_print(ACS_PRINT_INFO, "\n       BDF 0x%x: AER Cap supported", bdf);
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCiEP type device found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p017_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p018.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p018.c
@@ -1,0 +1,105 @@
+/** @file
+ * Copyright (c) 2020,2021,2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 18)
+#define TEST_RULE  "ME_AER_050_010, ME_SID_090_010"
+#define TEST_DESC  "Check RCiEP support ACS and AER capability       "
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP */
+      if (dp_type == RCiEP)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Read the ACS Capability */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base) != PCIE_SUCCESS)
+          {
+              val_print(ACS_PRINT_ERR, "\n       ACS Capability not supported, Bdf : 0x%x", bdf);
+              continue;
+          }
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+
+          /* If ACS Support but AER Not Supported, Fail. */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: AER Cap unsupported", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCiEP type device support ACS found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+
+uint32_t
+os_p018_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p019.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p019.c
@@ -1,0 +1,104 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 19)
+#define TEST_RULE  "ME_AER_060_010"
+#define TEST_DESC  "Check RCiEP support AER and RCEC capability......"
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP */
+      if (dp_type == RCiEP)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Read the AER Capability */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS)
+          {
+              val_print(ACS_PRINT_ERR, "\n       AER Capability not supported, Bdf : 0x%x", bdf);
+              continue;
+          }
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+
+          /* If AER Support but RCEC Not Supported, Fail. */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_RCECEA, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR,
+                "\n       BDF - 0x%x does not support RCEC Endpoint Association Capability", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCiEP type device support AER found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p019_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p020.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p020.c
@@ -1,0 +1,183 @@
+/** @file
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 20)
+#define TEST_RULE  "ME_AER_070_010, ME_SID_100_010"
+#define TEST_DESC  "Check RCEC device is fully function and correctly associated to RCiEP          "
+
+static
+uint32_t
+check_associated_rciep_support_aer(uint32_t bdf, uint32_t bit_map, uint32_t next_bus, uint32_t last_bus)
+{
+  uint32_t index;
+  uint32_t rcec_seg_num;
+  uint32_t rcec_bus_num;
+  uint32_t dev_bdf;
+  uint32_t bus_num;
+  uint32_t cap_base = 0;
+
+  rcec_seg_num = PCIE_EXTRACT_BDF_SEG(bdf);
+  rcec_bus_num = PCIE_EXTRACT_BDF_BUS(bdf);
+  /* Check associated RCiEP under the same bus of RCEC */
+  for (index = 0; index < PCIE_MAX_DEV; index++)
+  {
+    if ((1 << index) & bit_map) {
+      dev_bdf = PCIE_CREATE_BDF(rcec_seg_num, rcec_bus_num, index, 0);
+      if (val_pcie_device_port_type(dev_bdf) == RCiEP) {
+        /* If AER Not Supported, Fail. */
+        if (val_pcie_find_capability(dev_bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS) {
+            val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: AER Cap unsupported", dev_bdf);
+            return 0;
+        }
+      }
+    }
+  }
+  /* Check associated RCiEP not under the same bus of RCEC */
+  if (last_bus >= next_bus) {
+    for (bus_num = next_bus; bus_num <= last_bus; bus_num++)
+    {
+      for (index = 0; index < PCIE_MAX_DEV; index++)
+      {
+          dev_bdf = PCIE_CREATE_BDF(rcec_seg_num, bus_num, index, 0);
+          if (val_pcie_device_port_type(dev_bdf) == RCiEP) {
+            /* If AER Not Supported, Fail. */
+            if (val_pcie_find_capability(dev_bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS) {
+                val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: AER Cap unsupported", dev_bdf);
+                return 0;
+            }
+          }
+      }
+    }
+  }
+
+  return 1;
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t reg_value;
+  uint32_t rcec_ver;
+  uint32_t rcec_bitmap;
+  uint32_t rcec_next_bus;
+  uint32_t rcec_last_bus;
+  uint32_t ret;
+  uint32_t rcec_dev_num;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCEC */
+      if (dp_type == RCEC)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+
+          /* Read the RCECEA Capability. */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_RCECEA, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR,
+                "\n       BDF - 0x%x does not support RCEC Endpoint Association Capability", bdf);
+              test_fails++;
+              continue;
+          }
+
+          /* Read RCEC cap version */
+          val_pcie_read_cfg(bdf, RCEC_EA_CAP_OFFSET, &reg_value);
+          rcec_ver = VAL_EXTRACT_BITS(reg_value, RCEC_EA_CAP_VER_SHIFT, RCEC_EA_CAP_VER_SHIFT + 4);
+          val_print(ACS_PRINT_DEBUG, "\n RCEC cap version %d", rcec_ver);
+          /* Read Association Bitmap for RCiEP */
+          val_pcie_read_cfg(bdf, RCEC_EA_BITMAP_OFFSET, &rcec_bitmap);
+          val_print(ACS_PRINT_DEBUG, "\n RCEC Association Bitmap for RCiEP %d", rcec_bitmap);
+          /* If RCEC cap version > 2h，read Association Bus Numbers for RCiEP*/
+          if (rcec_ver > 2) {
+            val_pcie_read_cfg(bdf, RCEC_EA_BUS_OFFSET, &reg_value);
+            rcec_next_bus = VAL_EXTRACT_BITS(reg_value, RCEC_EA_NEXT_BUS_SHIFT, RCEC_EA_NEXT_BUS_SHIFT + 8);
+            rcec_last_bus = VAL_EXTRACT_BITS(reg_value, RCEC_EA_LAST_BUS_SHIFT, RCEC_EA_LAST_BUS_SHIFT + 8);
+            val_print(ACS_PRINT_DEBUG, "\n Association Next Bus Numbers for RCiEP %d", rcec_next_bus);
+            val_print(ACS_PRINT_DEBUG, " Association Bus Last Numbers for RCiEP %d", rcec_last_bus);
+          }
+
+          // Check if associated RCiEP support AER capability. if not, fail.
+          rcec_dev_num = PCIE_EXTRACT_BDF_DEV(bdf);
+          if (((1 << rcec_dev_num) == rcec_bitmap) && (rcec_next_bus == 0xFF) && (rcec_last_bus == 0)) {
+            val_print(ACS_PRINT_DEBUG, "\n RCEC BDF %d has no associated RCiEP", bdf);
+            continue;
+          } else {
+            ret = check_associated_rciep_support_aer(bdf, rcec_bitmap, rcec_next_bus, rcec_last_bus);
+            if (ret == 0) {
+              test_fails++;
+              continue;
+            }
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCEC type device found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p020_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p021.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p021.c
@@ -1,0 +1,157 @@
+/** @file
+ * Copyright (c) 2019-2020,2021 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 21)
+#define TEST_RULE  "MF_VSR_010_010"
+#define TEST_DESC  "Vendor specific data is PCIe compliant      "
+
+// Valid PCIe CapID ranges (PCIe 6.0 - v1.0)
+#define PCIE_CAP_ID_END     0x15
+#define PCIE_ECAP_ID_END    0x34
+
+#define HB_CLASSCODE      0x0600
+#define IOMMU_CLASSCODE   0x0806
+
+/*
+ Check if vendor specific data are presented as non-PCIe compliant capabilities
+ in either the regular or extended PCIe spaces
+ returns: 0 - No violations present    1 - One or more violations present
+ */
+static
+uint32_t
+check_pcie_cfg_space(uint32_t bdf)
+{
+    uint32_t reg_value;
+    uint32_t next_cap;
+    uint32_t err = 0;
+    uint32_t cid;
+
+    // Search through regular PCIe cfg space first (start at first implemented cap)
+    val_pcie_read_cfg(bdf, TYPE01_CPR, &reg_value);
+    // DWORD aligned: next_cap[1:0] are hardwired to '0'
+    next_cap = VAL_EXTRACT_BITS(reg_value, 2, 7) << 2;
+
+    while (next_cap) {
+
+        val_pcie_read_cfg(bdf, next_cap, &reg_value);
+        next_cap = VAL_EXTRACT_BITS(reg_value, 8, 15);
+        cid = VAL_EXTRACT_BITS(reg_value, 0, 7);
+
+        // Check PCIe Cap IDs are in range
+        if (cid > PCIE_CAP_ID_END) {
+            val_print(ACS_PRINT_ERR,
+                "\n       Invalid Cap ID: 0x%x found in regular cfg space", cid);
+            err = 1;
+        }
+    }
+
+    // Search through extended PCIe cfg space next
+    next_cap = PCIE_ECAP_START;
+
+    while (next_cap) {
+
+        val_pcie_read_cfg(bdf, next_cap, &reg_value);
+        next_cap = VAL_EXTRACT_BITS(reg_value, 20, 31);
+        cid = VAL_EXTRACT_BITS(reg_value, 0, 15);
+
+        // Check PCIe Ext Cap IDs are in range
+        if (cid > PCIE_ECAP_ID_END) {
+            val_print(ACS_PRINT_ERR,
+                "\n       Invalid Cap ID: 0x%x found in extended cfg space", cid);
+            err = 1;
+        }
+    }
+
+    return err;
+}
+
+static
+void
+payload(void)
+{
+    uint32_t hart_index;
+    uint32_t tbl_index;
+    uint32_t bdf;
+    uint32_t reg_value;
+    uint32_t class_code;
+    uint32_t dp_type;
+    uint32_t test_skip = 1;
+    uint32_t test_fail = 0;
+
+    pcie_device_bdf_table *bdf_tbl_ptr;
+
+    hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+    bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+    tbl_index = 0;
+
+    while (tbl_index < bdf_tbl_ptr->num_entries) {
+
+        bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+        dp_type = val_pcie_device_port_type(bdf);
+        val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
+        class_code = VAL_EXTRACT_BITS(reg_value, 16, 31);
+
+        // Only check for Root Ports, RCiEPs, IOMMUs and PCIe HBs
+        if ((dp_type == RP) || (dp_type == RCiEP) || (class_code == HB_CLASSCODE) || (class_code == IOMMU_CLASSCODE)) {
+            test_skip = 0;
+            val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+            val_print(ACS_PRINT_DEBUG, "\n       ClassCode - 0x%x", class_code);
+            if (check_pcie_cfg_space(bdf)) {
+                val_print(ACS_PRINT_ERR,
+                    "\n       Invalid PCIe capability found on dev: %d", tbl_index);
+                test_fail++;
+            }
+        }
+    }
+
+    if (test_skip)
+        val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 1));
+    else if (test_fail)
+        val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fail));
+    else
+        val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+
+    return;
+}
+
+uint32_t
+os_p021_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p022.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p022.c
@@ -1,0 +1,143 @@
+/** @file
+ * Copyright (c) 2019-2020,2021 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 22)
+#define TEST_RULE  "MF_SID_020_010"
+#define TEST_DESC  "Check RP and RCiEP disable I/O BAR and int pin      "
+
+static
+uint8_t
+check_pcie_has_iobar(uint32_t bdf)
+{
+  uint32_t index;
+  uint32_t bar_low32bits = 0;
+
+  index = 0;
+  while (index < TYPE1_MAX_BARS)
+  {
+    /* Read the base address register at loop index */
+    val_pcie_read_cfg(bdf, TYPE01_BAR + index * 4, &bar_low32bits);
+    /* Check if the BAR is Memory Mapped IO type */
+    if (((bar_low32bits >> BAR_MIT_SHIFT) & BAR_MIT_MASK) == IO)
+    {
+        return 1;
+    }
+
+    /* Adjust index to point to next BAR */
+    index++;
+  }
+
+  return 0;
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t reg_value;
+  uint32_t int_pin;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP or RP*/
+      if ((dp_type == RCiEP) || (dp_type == RP))
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+
+          /* Check I/O BAR */
+          if (check_pcie_has_iobar(bdf)) {
+            val_print(ACS_PRINT_ERR, "\n       BDF - 0x%x has I/O BAR", bdf);
+            test_fails++;
+            continue;
+          }
+
+          /* Check EA Capability */
+          if (val_pcie_find_capability(bdf, PCIE_CAP, CID_EA, &cap_base) == PCIE_SUCCESS)
+          {
+              val_print(ACS_PRINT_ERR, "\n       EA Capability is supported, Bdf : 0x%x", bdf);
+              test_fails++;
+              continue;
+          }
+
+          /* Check int pin register is zero. */
+          val_pcie_read_cfg(bdf, TYPE01_ILR, &reg_value);
+          int_pin = VAL_EXTRACT_BITS(reg_value, TYPE01_IPR_SHIFT, TYPE01_IPR_SHIFT + 7);
+          if(int_pin != 0) {
+            val_print(ACS_PRINT_DEBUG, "\n BDF - 0x%x int pin register value is not zero", bdf);
+            test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP or RCiEP type device found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p022_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p023.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p023.c
@@ -1,0 +1,105 @@
+/** @file
+ * Copyright (c) 2020,2021,2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 23)
+#define TEST_RULE  "ME_SID_040_010"
+#define TEST_DESC  "Check RCiEP support SR-IOV and MSI-X capability       "
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t cap_base = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP */
+      if (dp_type == RCiEP)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          /* Read the SRIOV Capability */
+          if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_SRIOV, &cap_base) != PCIE_SUCCESS)
+          {
+              val_print(ACS_PRINT_ERR, "\n       SR-IOV Capability not supported, Bdf : 0x%x", bdf);
+              continue;
+          }
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+
+          /* If SR-IOV Support but MSI-X Not Supported, Fail. */
+          if (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base) != PCIE_SUCCESS) {
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: MSI-X Cap unsupported", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCiEP type device support SR-IOV found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+
+uint32_t
+os_p023_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p024.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p024.c
@@ -1,0 +1,124 @@
+/** @file
+ * Copyright (c) 2019-2020,2021 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 24)
+#define TEST_RULE  "ME_SID_050_010"
+#define TEST_DESC  "Check RCiEP PASID capability          "
+
+#define MIN_PASID_SUPPORT 20
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t status;
+  uint32_t max_pasids = 0;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP */
+      if (dp_type == RCiEP)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+          /* Get max PASID with from device bdf */
+          status = val_pcie_get_max_pasid_width(bdf, &max_pasids);
+          /* Skip the device if PASID extended capability not supported */
+          if (status == PCIE_CAP_NOT_FOUND)
+          {
+              val_print(ACS_PRINT_DEBUG, "\n       PASID extended capability not supported.", 0);
+              val_print(ACS_PRINT_DEBUG, " Skipping for BDF: 0x%x", bdf);
+              continue;
+          }
+          /* Raise an error if any failure in obtaining the PASID max width */
+          else if (status)
+          {
+              test_skip = 0;
+              val_print(ACS_PRINT_ERR,
+                              "\n       Error in obtaining the PASID max width for BDF: 0x%x", bdf);
+              test_fails++;
+              continue;
+          }
+
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+          val_print(ACS_PRINT_DEBUG, "- Max PASID bits - 0x%x", max_pasids);
+          /* If PASID Support, Max PASID Width should be 20 bits. */
+          if (max_pasids > 0)
+          {
+              if (max_pasids < MIN_PASID_SUPPORT)
+              {
+                  val_print(ACS_PRINT_ERR, "\n       Max PASID support less than 20 bits  ", 0);
+                  test_fails++;
+              }
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCiEP type device support PASID found, Skipping test", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p024_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/riscv/test_os_p025.c
+++ b/test_pool/pcie/operating_system/riscv/test_os_p025.c
@@ -1,0 +1,146 @@
+/** @file
+ * Copyright (c) 2019-2020,2021 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_hart.h"
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 25)
+#define TEST_RULE  "ME_SID_070_010"
+#define TEST_DESC  "Check RCiEP support 64 bit MMIO bar          "
+
+#define NO_BAR       0xFF
+
+static
+uint8_t
+check_pcie_has_bar(uint32_t bdf, uint32_t *bar_type)
+{
+  uint32_t index;
+  uint32_t bar_low32bits = 0;
+  uint32_t bar_high32bits = 0;
+
+  index = 0;
+  while (index < TYPE1_MAX_BARS)
+  {
+    /* Read the base address register at loop index */
+    val_pcie_read_cfg(bdf, TYPE01_BAR + index * 4, &bar_low32bits);
+    /* Check if the BAR is Memory Mapped IO type */
+    if (((bar_low32bits >> BAR_MIT_SHIFT) & BAR_MIT_MASK) == MMIO)
+    {
+        /* Check if the BAR is 64-bit decodable */
+        if (((bar_low32bits >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_64)
+        {
+            /* Read the second sequential BAR at next index */
+            val_pcie_read_cfg(bdf, TYPE01_BAR + (index + 1) * 4, &bar_high32bits);
+
+            /* Adjust the index to skip next sequential BAR */
+            *bar_type = BAR_64_BIT;
+            index++;
+
+        } else if (((bar_low32bits >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_32)
+        {
+          /* Fill lower 32-bits of 64-bit address with first sequential BAR */
+          *bar_type = BAR_32_BIT;
+        }
+        return 1;
+    }
+
+    /* Adjust index to point to next BAR */
+    index++;
+  }
+
+  return 0;
+}
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t hart_index;
+  uint32_t tbl_index;
+  uint32_t dp_type;
+  uint32_t bar_type;
+  uint32_t test_fails;
+  uint32_t test_skip = 1;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  hart_index = val_hart_get_index_mpid(val_hart_get_mpid());
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  test_fails = 0;
+
+  /* Check for all the function present in bdf table */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      /* Check entry is RCiEP */
+      if (dp_type == RCiEP)
+      {
+          if (check_pcie_has_bar(bdf, &bar_type) == 0) {
+            val_print(ACS_PRINT_DEBUG, "\n       RCiEP (BDF:0x%x) does not have MMIO BAR. Skipping test", bdf);
+            continue;
+          }
+          
+          /* Test runs for atleast an endpoint */
+          test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
+          if (bar_type != BAR_64_BIT) {
+              val_print(ACS_PRINT_ERR,
+                    "\n       64 bit bar Check Failed, Bdf : 0x%x", bdf);
+              test_fails++;
+          }
+      }
+  }
+
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RCiEP type device which support bar found. Skipping device", 0);
+      val_set_status(hart_index, RESULT_SKIP(TEST_NUM, 2));
+  }
+  else if (test_fails)
+      val_set_status(hart_index, RESULT_FAIL(TEST_NUM, test_fails));
+  else
+      val_set_status(hart_index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_p025_entry(uint32_t num_hart)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_hart = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_hart);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_hart, payload, 0);
+
+  /* get the result from all HART and check for failure */
+  status = val_check_for_error(TEST_NUM, num_hart, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -163,6 +163,7 @@
   ../test_pool/iommu/operating_system/test_os_iom002.c
   ../test_pool/iommu/operating_system/test_os_iom003.c
   ../test_pool/iommu/operating_system/test_os_iom004.c
+  ../test_pool/iommu/operating_system/test_os_iom005.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -165,6 +165,7 @@
   ../test_pool/iommu/operating_system/test_os_iom004.c
   ../test_pool/iommu/operating_system/test_os_iom005.c
   ../test_pool/iommu/operating_system/test_os_iom008.c
+  ../test_pool/iommu/operating_system/test_os_iom011.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -212,6 +212,10 @@
   ../test_pool/pcie/operating_system/riscv/test_os_p007.c
   ../test_pool/pcie/operating_system/riscv/test_os_p008.c
   ../test_pool/pcie/operating_system/riscv/test_os_p009.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p010.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p011.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p012.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p013.c
   # ../test_pool/pcie/operating_system/test_os_p002.c
   # ../test_pool/pcie/operating_system/test_os_p003.c
   # ../test_pool/pcie/operating_system/test_os_p006.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -160,6 +160,7 @@
   # ../test_pool/memory_map/operating_system/test_os_m002.c
   # ../test_pool/memory_map/operating_system/test_os_m003.c
   ../test_pool/iommu/operating_system/test_os_iom001.c
+  ../test_pool/iommu/operating_system/test_os_iom002.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -204,6 +204,10 @@
   # ../test_pool/watchdog/operating_system/test_os_w001.c
   # ../test_pool/watchdog/operating_system/test_os_w002.c
   ../test_pool/pcie/operating_system/test_os_p001.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p002.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p003.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p004.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p005.c
   # ../test_pool/pcie/operating_system/test_os_p002.c
   # ../test_pool/pcie/operating_system/test_os_p003.c
   # ../test_pool/pcie/operating_system/test_os_p006.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -208,6 +208,10 @@
   ../test_pool/pcie/operating_system/riscv/test_os_p003.c
   ../test_pool/pcie/operating_system/riscv/test_os_p004.c
   ../test_pool/pcie/operating_system/riscv/test_os_p005.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p006.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p007.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p008.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p009.c
   # ../test_pool/pcie/operating_system/test_os_p002.c
   # ../test_pool/pcie/operating_system/test_os_p003.c
   # ../test_pool/pcie/operating_system/test_os_p006.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -169,6 +169,7 @@
   ../test_pool/iommu/operating_system/test_os_iom013.c
   ../test_pool/iommu/operating_system/test_os_iom014.c
   ../test_pool/iommu/operating_system/test_os_iom017.c
+  ../test_pool/iommu/operating_system/test_os_iom019.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -170,6 +170,7 @@
   ../test_pool/iommu/operating_system/test_os_iom014.c
   ../test_pool/iommu/operating_system/test_os_iom017.c
   ../test_pool/iommu/operating_system/test_os_iom019.c
+  ../test_pool/iommu/operating_system/test_os_iom022.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -164,6 +164,7 @@
   ../test_pool/iommu/operating_system/test_os_iom003.c
   ../test_pool/iommu/operating_system/test_os_iom004.c
   ../test_pool/iommu/operating_system/test_os_iom005.c
+  ../test_pool/iommu/operating_system/test_os_iom008.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -171,6 +171,7 @@
   ../test_pool/iommu/operating_system/test_os_iom017.c
   ../test_pool/iommu/operating_system/test_os_iom019.c
   ../test_pool/iommu/operating_system/test_os_iom022.c
+  ../test_pool/iommu/operating_system/test_os_iom024.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -172,6 +172,7 @@
   ../test_pool/iommu/operating_system/test_os_iom019.c
   ../test_pool/iommu/operating_system/test_os_iom022.c
   ../test_pool/iommu/operating_system/test_os_iom024.c
+  ../test_pool/iommu/operating_system/test_os_iom026.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -168,6 +168,7 @@
   ../test_pool/iommu/operating_system/test_os_iom011.c
   ../test_pool/iommu/operating_system/test_os_iom013.c
   ../test_pool/iommu/operating_system/test_os_iom014.c
+  ../test_pool/iommu/operating_system/test_os_iom017.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -167,6 +167,7 @@
   ../test_pool/iommu/operating_system/test_os_iom008.c
   ../test_pool/iommu/operating_system/test_os_iom011.c
   ../test_pool/iommu/operating_system/test_os_iom013.c
+  ../test_pool/iommu/operating_system/test_os_iom014.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -161,6 +161,8 @@
   # ../test_pool/memory_map/operating_system/test_os_m003.c
   ../test_pool/iommu/operating_system/test_os_iom001.c
   ../test_pool/iommu/operating_system/test_os_iom002.c
+  ../test_pool/iommu/operating_system/test_os_iom003.c
+  ../test_pool/iommu/operating_system/test_os_iom004.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -166,6 +166,7 @@
   ../test_pool/iommu/operating_system/test_os_iom005.c
   ../test_pool/iommu/operating_system/test_os_iom008.c
   ../test_pool/iommu/operating_system/test_os_iom011.c
+  ../test_pool/iommu/operating_system/test_os_iom013.c
   ../test_pool/iic/operating_system/test_os_i001.c
   ../test_pool/iic/operating_system/test_os_i002.c
   ../test_pool/iic/operating_system/test_os_i003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -216,6 +216,18 @@
   ../test_pool/pcie/operating_system/riscv/test_os_p011.c
   ../test_pool/pcie/operating_system/riscv/test_os_p012.c
   ../test_pool/pcie/operating_system/riscv/test_os_p013.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p014.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p015.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p016.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p017.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p018.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p019.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p020.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p021.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p022.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p023.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p024.c
+  ../test_pool/pcie/operating_system/riscv/test_os_p025.c
   # ../test_pool/pcie/operating_system/test_os_p002.c
   # ../test_pool/pcie/operating_system/test_os_p003.c
   # ../test_pool/pcie/operating_system/test_os_p006.c

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -24,4 +24,7 @@ os_iom005_entry(uint32_t num_hart);
 
 uint32_t
 os_iom008_entry(uint32_t num_hart);
+
+uint32_t
+os_iom011_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -21,4 +21,7 @@ os_iom004_entry(uint32_t num_hart);
 
 uint32_t
 os_iom005_entry(uint32_t num_hart);
+
+uint32_t
+os_iom008_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -39,4 +39,7 @@ os_iom017_entry(uint32_t num_hart);
 
 uint32_t
 os_iom019_entry(uint32_t num_hart);
+
+uint32_t
+os_iom022_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -42,4 +42,7 @@ os_iom019_entry(uint32_t num_hart);
 
 uint32_t
 os_iom022_entry(uint32_t num_hart);
+
+uint32_t
+os_iom024_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -10,4 +10,6 @@
 uint32_t
 os_iom001_entry(uint32_t num_hart);
 
+uint32_t
+os_iom002_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -36,4 +36,7 @@ os_iom014_entry(uint32_t num_hart);
 
 uint32_t
 os_iom017_entry(uint32_t num_hart);
+
+uint32_t
+os_iom019_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -33,4 +33,7 @@ os_iom013_entry(uint32_t num_hart);
 
 uint32_t
 os_iom014_entry(uint32_t num_hart);
+
+uint32_t
+os_iom017_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -45,4 +45,8 @@ os_iom022_entry(uint32_t num_hart);
 
 uint32_t
 os_iom024_entry(uint32_t num_hart);
+
+uint32_t
+os_iom026_entry(uint32_t num_hart);
+
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -18,4 +18,7 @@ os_iom003_entry(uint32_t num_hart);
 
 uint32_t
 os_iom004_entry(uint32_t num_hart);
+
+uint32_t
+os_iom005_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -30,4 +30,7 @@ os_iom011_entry(uint32_t num_hart);
 
 uint32_t
 os_iom013_entry(uint32_t num_hart);
+
+uint32_t
+os_iom014_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -27,4 +27,7 @@ os_iom008_entry(uint32_t num_hart);
 
 uint32_t
 os_iom011_entry(uint32_t num_hart);
+
+uint32_t
+os_iom013_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_iommu.h
+++ b/val/include/bsa_acs_iommu.h
@@ -12,4 +12,10 @@ os_iom001_entry(uint32_t num_hart);
 
 uint32_t
 os_iom002_entry(uint32_t num_hart);
+
+uint32_t
+os_iom003_entry(uint32_t num_hart);
+
+uint32_t
+os_iom004_entry(uint32_t num_hart);
 #endif

--- a/val/include/bsa_acs_pcie.h
+++ b/val/include/bsa_acs_pcie.h
@@ -177,7 +177,8 @@ typedef enum {
   PCIE_INFO_MCFG_ECAM,
   PCIE_INFO_START_BUS,
   PCIE_INFO_END_BUS,
-  PCIE_INFO_SEGMENT
+  PCIE_INFO_SEGMENT,
+  PCIE_INFO_DSDT_PTR
 }PCIE_INFO_e;
 
 uint64_t
@@ -237,6 +238,7 @@ uint32_t os_p003_entry(uint32_t num_hart);
 uint32_t os_p004_entry(uint32_t num_hart);
 uint32_t os_p005_entry(uint32_t num_hart);
 uint32_t os_p006_entry(uint32_t num_hart);
+uint32_t os_p007_entry(uint32_t num_hart);
 uint32_t os_p008_entry(uint32_t num_hart);
 uint32_t os_p009_entry(uint32_t num_hart);
 uint32_t os_p010_entry(uint32_t num_hart);

--- a/val/include/bsa_acs_pcie.h
+++ b/val/include/bsa_acs_pcie.h
@@ -161,6 +161,7 @@ typedef struct {
 } pcie_device_bdf_table;
 
 void     val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data);
+void     val_pcie_write_cfg_width(uint32_t bdf, uint32_t offset, void *data, PCI_WIDTH_TYPE width);
 void     val_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data);
 uint32_t val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data);
 uint32_t val_pcie_read_cfg_width(uint32_t bdf, uint32_t offset, void *data, PCI_WIDTH_TYPE width);

--- a/val/include/bsa_acs_pcie_spec.h
+++ b/val/include/bsa_acs_pcie_spec.h
@@ -196,6 +196,7 @@
 #define ECID_ACS       0x000D
 #define ECID_ARICS     0x000E
 #define ECID_ATS       0x000F
+#define ECID_SRIOV     0x0010
 #define ECID_AF        0x0013
 #define ECID_PASID     0x001B
 #define ECID_DPC       0x001D
@@ -264,6 +265,8 @@
 #define DPC_TRIGGER_SHIFT      0x1
 #define DPC_DISABLE_MASK       0xFFFCFFFF
 #define DPC_INTR_ENABLE        0x80000
+#define DPC_RP_EXT_OFFSET      0x5
+#define DPC_RP_EXT_MASK        0x1
 
 /* AER Capability struct offsets and shifts */
 #define AER_UNCORR_STATUS_OFFSET 0x4
@@ -420,5 +423,16 @@
 #define FLR_CAP_EN                  (1 << 1)
 #define AF_CTRL                     0x4
 #define FLR_EN                      (1 << 0)
+
+/* RCEC Endpoint Association Capabilities */
+#define RCEC_EA_CAP_OFFSET          0x0
+#define RCEC_EA_CAP_VER_SHIFT       (16)
+#define RCEC_EA_CAP_VER_MASK        0xF
+#define RCEC_EA_BITMAP_OFFSET       0x4
+#define RCEC_EA_BUS_OFFSET          0x8
+#define RCEC_EA_NEXT_BUS_SHIFT      (8)
+#define RCEC_EA_NEXT_BUS_MASK       0xFF
+#define RCEC_EA_LAST_BUS_SHIFT      (16)
+#define RCEC_EA_LAST_BUS_MASK       0xFF
 
 #endif

--- a/val/include/bsa_acs_pcie_spec.h
+++ b/val/include/bsa_acs_pcie_spec.h
@@ -199,6 +199,7 @@
 #define ECID_AF        0x0013
 #define ECID_PASID     0x001B
 #define ECID_DPC       0x001D
+#define ECID_PTM       0x001E
 #define ECID_DVSEC     0x0023
 
 /* PCI Express capability struct offsets */

--- a/val/include/bsa_acs_pcie_spec.h
+++ b/val/include/bsa_acs_pcie_spec.h
@@ -196,7 +196,7 @@
 #define ECID_ACS       0x000D
 #define ECID_ARICS     0x000E
 #define ECID_ATS       0x000F
-#define ECID_PRI       0x0013
+#define ECID_AF        0x0013
 #define ECID_PASID     0x001B
 #define ECID_DPC       0x001D
 #define ECID_DVSEC     0x0023
@@ -209,6 +209,8 @@
 #define DCTLR_OFFSET   0x8
 #define LCAPR_OFFSET   0xC
 #define LCTRLR_OFFSET  0x10
+#define RTCTRL_OFFSET  0x1C
+#define ROOTCP_OFFSET  0x1E
 #define DCAP2R_OFFSET  0x24
 #define DCTL2R_OFFSET  0x28
 #define LCAP2R_OFFSET  0x2C
@@ -367,6 +369,10 @@
 #define DCTL2R_AFE_MASK  0x1
 #define DCTL2R_AFE_NORMAL 0xFFDF
 
+/* Root Control Register */
+#define CSR_EN_SHIFT     (1 << 4)
+#define CSR_ENABLE       (1 << 4)
+
 /* Device bitmask definitions */
 #define RCiEP    (1 << 0b1001)
 #define RCEC     (1 << 0b1010)
@@ -379,6 +385,10 @@
 #define PCI_PCIE (1 << 0b1000)
 #define PCIE_PCI (1 << 0b0111)
 #define PCIe_ALL (iEP_RP | iEP_EP | RP | EP | RCEC | RCiEP)
+
+/* Link Control Register*/
+#define LINK_DISABLE_SHIFT      (1 << 4)
+#define LINK_DISABLE            (1 << 4)
 
 /* MSI-X Capabilities */
 #define MSI_X_ENABLE_SHIFT          31
@@ -403,5 +413,11 @@
 #define ATS_CTRL                    0x4
 #define ATS_CACHING_EN              (1 << 31)
 #define ATS_CACHING_DIS             0x7FFFFFFF
+
+/* Advance Features Capabilities */
+#define AF_CAPABILITY_OFFSET        0x3
+#define FLR_CAP_EN                  (1 << 1)
+#define AF_CTRL                     0x4
+#define FLR_EN                      (1 << 0)
 
 #endif

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -255,17 +255,34 @@ typedef struct {
   uint32_t  num_of_iommu;
 } IOMMU_INFO_HDR;
 
+/**
+  @brief  ID Mapping Structure
+**/
+typedef struct {
+  uint32_t  sourceid_base;
+  uint32_t  numids;
+  uint32_t  destid_base;
+  uint32_t  destiommu_offset;
+} ID_MAPPTING_TABLE;
+
 typedef struct {
   uint32_t  iommu_num;  ///< info entry index
   uint8_t   type;
   uint16_t  id;
 
   /* IOMMU device specific */
+  uint32_t  iommu_offset;
   uint64_t  hardware_id;
   uint64_t  base_address;
   uint32_t  flags;
+  uint16_t  pcie_seg;
+  uint16_t  pcie_bdf;
 
   /* PCIe Root Complex specific */
+  uint16_t  idmap_offset;
+  uint16_t  idmap_num;
+  uint16_t  pcie_rc_seg;
+  ID_MAPPTING_TABLE id_mapping_table[];
 } IOMMU_INFO_ENTRY;
 
 typedef struct {

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -201,6 +201,7 @@ typedef struct {
   uint64_t   imsic_base;      ///< Physical base address of the Incoming MSI Controller (IMSIC) MMIO region of this hart.
   uint32_t   imsic_size;      ///< Size in bytes of the IMSIC MMIO region of this hart.
   char8_t    isa_string[512]; ///< Null-terminated ASCII Instruction Set Architecture (ISA) string for this hart.
+  uint8_t    mmu_type;        ///< MMU type
 }HART_INFO_ENTRY;
 
 typedef struct {

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -74,6 +74,7 @@ void     val_hart_free_info_table(void);
 uint32_t val_hart_get_num(void);
 char8_t *val_hart_get_isa_string (uint32_t index);
 uint64_t val_hart_get_imsic_base (int32_t index);
+uint8_t val_hart_get_mmu_type (uint32_t index);
 uint64_t val_hart_get_mpid(void);
 uint32_t val_hart_get_index_mpid(uint64_t hart_id);
 uint32_t val_hart_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -105,9 +105,12 @@ uint32_t val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view);
 uint32_t val_iommu_create_info_table(uint64_t *iommu_info_table);
 void     val_iommu_free_info_table(void);
 uint32_t val_iommu_get_num(void);
+uint16_t val_iommu_get_idmap_num(int32_t index);
 uint64_t val_iommu_get_info(int32_t index, IOMMU_INFO_e info_type);
+uint64_t val_iommu_get_pcierc_platform_info(int32_t index, int32_t idmap_index, PCIERC_PLATFORM_INFO_e info_type);
 uint64_t val_iommu_read_iommu_reg(uint32_t index, uint32_t offset, uint32_t num);
 void val_iommu_write_iommu_reg(uint32_t index, uint32_t offset, uint32_t num, uint64_t data);
+uint8_t val_iommu_check_governing_iommu(uint32_t bdf, uint32_t *iommu_index);
 
 /* IIC VAL APIs */
 uint32_t    val_gic_create_info_table(uint64_t *gic_info_table);

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -87,12 +87,27 @@ int      val_suspend_pe(uint64_t entry, uint32_t context_id);
 typedef enum {
   IOMMU_INFO_TYPE=1,
   IOMMU_INFO_BASE_ADDRESS,
+  IOMMU_INFO_FLAGS,
+  IOMMU_INFO_PCIE_SEG,
+  IOMMU_INFO_PCIE_BDF,
+  IOMMU_INFO_IOMMU_OFFSET,
 }IOMMU_INFO_e;
+
+typedef enum {
+  IOMMU_INFO_PCIE_RC_SEG=1,
+  IOMMU_INFO_SOURCE_ID_BASE,
+  IOMMU_INFO_NUM_IDS,
+  IOMMU_INFO_DEST_ID_BASE,
+  IOMMU_INFO_DEST_IOMMU_OFFSET
+}PCIERC_PLATFORM_INFO_e;
+
 uint32_t val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view);
 uint32_t val_iommu_create_info_table(uint64_t *iommu_info_table);
 void     val_iommu_free_info_table(void);
 uint32_t val_iommu_get_num(void);
 uint64_t val_iommu_get_info(int32_t index, IOMMU_INFO_e info_type);
+uint64_t val_iommu_read_iommu_reg(uint32_t index, uint32_t offset, uint32_t num);
+void val_iommu_write_iommu_reg(uint32_t index, uint32_t offset, uint32_t num, uint64_t data);
 
 /* IIC VAL APIs */
 uint32_t    val_gic_create_info_table(uint64_t *gic_info_table);

--- a/val/src/acs_hart.c
+++ b/val/src/acs_hart.c
@@ -414,6 +414,30 @@ val_hart_get_imsic_base (int32_t index)
 }
 
 /**
+ * @brief  This API returns the HART MMU Type
+           for a given HART index
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_create_peinfo_table
+ *
+ * @param index
+ * @return HART MMU Type
+ */
+uint8_t
+val_hart_get_mmu_type (uint32_t index)
+{
+  HART_INFO_ENTRY *entry;
+
+  if (index > g_hart_info_table->header.num_of_hart) {
+        val_report_status(index, RESULT_FAIL(0, 0xFF), NULL);
+        return 0;
+  }
+
+  entry = g_hart_info_table->hart_info;
+
+  return entry[index].mmu_type;
+}
+
+/**
   @brief   This API will call an assembly sequence with interval
            as argument over which an SPE event is exected to be generated.
            1. Caller       -  Test Suite

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -46,6 +46,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom002_entry(num_hart);
       status |= os_iom003_entry(num_hart);
       status |= os_iom004_entry(num_hart);
+      status |= os_iom005_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -49,6 +49,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom005_entry(num_hart);
       status |= os_iom008_entry(num_hart);
       status |= os_iom011_entry(num_hart);
+      status |= os_iom013_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -48,6 +48,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom004_entry(num_hart);
       status |= os_iom005_entry(num_hart);
       status |= os_iom008_entry(num_hart);
+      status |= os_iom011_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -5,6 +5,10 @@
 
 IOMMU_INFO_TABLE  *g_iommu_info_table;
 
+void val_memory_map_add_mmio (uint64_t  Address, uint64_t  Length);
+uint32_t val_pcie_bar_mem_read(uint32_t bdf, uint64_t address, uint32_t *data);
+uint32_t val_pcie_bar_mem_write(uint32_t bdf, uint64_t address, uint32_t data);
+
 /**
   @brief   This API executes all the IOMMU tests sequentially
            1. Caller       -  Application layer.
@@ -88,7 +92,7 @@ val_iommu_free_info_table(void)
            1. Caller       -  Application layer, test Suite.
            2. Prerequisite -  val_hart_create_info_table.
   @param   none
-  @return  the number of hart discovered
+  @return  the number of iommu node discovered
 **/
 uint32_t
 val_iommu_get_num()
@@ -97,6 +101,22 @@ val_iommu_get_num()
       return 0;
   }
   return g_iommu_info_table->header.num_of_iommu;
+}
+
+/**
+  @brief   This API returns the number of IOMMU from the g_iommu_info_table.
+           1. Caller       -  Application layer, test Suite.
+           2. Prerequisite -  val_hart_create_info_table.
+  @param   none
+  @return  the number of idmap table discovered
+**/
+uint16_t
+val_iommu_get_idmap_num(int32_t index)
+{
+  if (g_iommu_info_table == NULL) {
+      return 0;
+  }
+  return g_iommu_info_table->iommu_info[index].idmap_num;
 }
 
 /**
@@ -120,7 +140,164 @@ val_iommu_get_info(int32_t index, IOMMU_INFO_e info_type)
         return g_iommu_info_table->iommu_info[index].type;
     case IOMMU_INFO_BASE_ADDRESS:
         return g_iommu_info_table->iommu_info[index].base_address;
+    case IOMMU_INFO_FLAGS:
+        return g_iommu_info_table->iommu_info[index].flags;
+    case IOMMU_INFO_PCIE_SEG:
+        return g_iommu_info_table->iommu_info[index].pcie_seg;
+    case IOMMU_INFO_PCIE_BDF:
+        return g_iommu_info_table->iommu_info[index].pcie_bdf;
+    case IOMMU_INFO_IOMMU_OFFSET:
+        return g_iommu_info_table->iommu_info[index].iommu_offset;
     default:
       return 0;
   }
+}
+
+/**
+  @brief   This API is a single point of entry to retrieve
+           information stored in the IOMMU Info idmap table
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_hart_create_info_table
+  @param   index  IOMMU index in the table
+  @param   idmap_index  IDMAP index in the table
+  @param   type   the type of information being requested
+  @return  64-bit data
+**/
+uint64_t
+val_iommu_get_pcierc_platform_info(int32_t index, int32_t idmap_index, PCIERC_PLATFORM_INFO_e info_type)
+{
+  if (g_iommu_info_table == NULL)
+      return 0;
+
+  switch (info_type) {
+    case IOMMU_INFO_PCIE_RC_SEG:
+        return g_iommu_info_table->iommu_info[index].pcie_rc_seg;
+    case IOMMU_INFO_SOURCE_ID_BASE:
+        return g_iommu_info_table->iommu_info[index].id_mapping_table[idmap_index].sourceid_base;
+    case IOMMU_INFO_NUM_IDS:
+        return g_iommu_info_table->iommu_info[index].id_mapping_table[idmap_index].numids;
+    case IOMMU_INFO_DEST_ID_BASE:
+        return g_iommu_info_table->iommu_info[index].id_mapping_table[idmap_index].destid_base;
+    case IOMMU_INFO_DEST_IOMMU_OFFSET:
+        return g_iommu_info_table->iommu_info[index].id_mapping_table[idmap_index].destiommu_offset;
+    default:
+      return 0;
+  }
+}
+
+/**
+  @brief   This API is a single point of entry to get iommu reg value
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_hart_create_info_table
+  @param   index  IOMMU index in the table
+  @param   offset  offset of the register to be read
+  @param   num  number of dword to be read
+  @return  64-bit data
+**/
+uint64_t
+val_iommu_read_iommu_reg(uint32_t index, uint32_t offset, uint32_t num)
+{
+  uint32_t flags = 0;
+  uint64_t base_addr = 0;
+  uint16_t pcie_seg = 0;
+  uint16_t pcie_bdf = 0;
+  uint32_t bdf = 0;
+  uint64_t reg_value = 0;
+  uint64_t datahigh, datalow;
+
+  if (g_iommu_info_table == NULL)
+      return 0;
+  if ((offset > 1024) || (num > 2))
+      return 0;
+
+  if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      flags = val_iommu_get_info (index, IOMMU_INFO_FLAGS);
+      // val_print(ACS_PRINT_INFO, "\n       IOMMU FLAGS: 0x%x", flags);
+      if ((flags & 0x01) == 0) { // IOMMU is implemented as a platform device
+        base_addr = val_iommu_get_info (index, IOMMU_INFO_BASE_ADDRESS);
+        /* Map the IOMMU memory-mapped register region */
+        val_memory_map_add_mmio(base_addr, 0x1000);
+        if (num == 1) {
+          reg_value = val_mmio_read(base_addr + offset);
+        } else if (num == 2) {
+          reg_value = val_mmio_read64(base_addr + offset);
+        }
+      } else if ((flags & 0x01) == 1) { // IOMMU is implemented as a PCIe device
+        pcie_seg = val_iommu_get_info (index, IOMMU_INFO_PCIE_SEG);
+        pcie_bdf = val_iommu_get_info (index, IOMMU_INFO_PCIE_BDF);
+        // val_print(ACS_PRINT_INFO, "\n       IOMMU PCIE_RID: 0x%x", pcie_bdf);
+        // pcie_bdf(PRID format bus << 8 dev << 3 func) transfer to pcie format(seg << 24 bus << 16 dev << 8 func)
+        bdf = ((pcie_seg << 24) | (pcie_bdf & 0xff00) << 8) | ((pcie_bdf & 0x00f8) << 5) | ((pcie_bdf & 0x0007));
+        // val_print(ACS_PRINT_INFO, "\n       IOMMU pcie_bdf: 0x%x", bdf);
+        val_pcie_get_mmio_bar (bdf, &base_addr);
+        if (num == 1) {
+          val_pcie_bar_mem_read (bdf, base_addr + offset, (uint32_t *)&reg_value);
+        } else if (num == 2) {
+          val_pcie_bar_mem_read (bdf, base_addr + offset, (uint32_t *)&datalow);
+          val_pcie_bar_mem_read (bdf, base_addr + offset + 4, (uint32_t *)&datahigh);
+          reg_value = ((datahigh & 0xffffffff) << 32) | (datalow & 0xffffffff);
+        }
+      }
+  }
+  // val_print(ACS_PRINT_INFO, "\n       IOMMU base: 0x%lx", base_addr);
+  // val_print(ACS_PRINT_INFO, "\n       IOMMU REG: 0x%x", reg_value);
+
+  return reg_value;
+}
+
+/**
+  @brief   This API is a single point of entry to get iommu reg value
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_hart_create_info_table
+  @param   index  IOMMU index in the table
+  @param   offset  offset of the register to be read
+  @param   num  number of dword to be read
+  @return  64-bit data
+**/
+void
+val_iommu_write_iommu_reg(uint32_t index, uint32_t offset, uint32_t num, uint64_t data)
+{
+  uint32_t flags = 0;
+  uint64_t base_addr = 0;
+  uint16_t pcie_seg = 0;
+  uint16_t pcie_bdf = 0;
+  uint32_t bdf = 0;
+
+  if (g_iommu_info_table == NULL)
+      return;
+  if ((offset > 1024) || (num > 2))
+      return;
+
+  if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      flags = val_iommu_get_info (index, IOMMU_INFO_FLAGS);
+      // val_print(ACS_PRINT_INFO, "\n       IOMMU FLAGS: 0x%x", flags);
+      if ((flags & 0x01) == 0) { // IOMMU is implemented as a platform device
+        base_addr = val_iommu_get_info (index, IOMMU_INFO_BASE_ADDRESS);
+        /* Map the IOMMU memory-mapped register region */
+        val_memory_map_add_mmio(base_addr, 0x1000);
+        if (num == 1) {
+          val_mmio_write(base_addr + offset, (uint32_t)data);
+        } else if (num == 2) {
+          val_mmio_write64(base_addr + offset, (uint64_t)data);
+        }
+      } else if ((flags & 0x01) == 1) { // IOMMU is implemented as a PCIe device
+        pcie_seg = val_iommu_get_info (index, IOMMU_INFO_PCIE_SEG);
+        pcie_bdf = val_iommu_get_info (index, IOMMU_INFO_PCIE_BDF);
+        // val_print(ACS_PRINT_INFO, "\n       IOMMU PCIE_RID: 0x%x", pcie_bdf);
+        // pcie_bdf(PRID format bus << 8 dev << 3 func) transfer to pcie format(seg << 24 bus << 16 dev << 8 func)
+        bdf = ((pcie_seg << 24) | (pcie_bdf & 0xff00) << 8) | ((pcie_bdf & 0x00f8) << 5) | ((pcie_bdf & 0x0007));
+        // val_print(ACS_PRINT_INFO, "\n       IOMMU pcie_bdf: 0x%x", bdf);
+        val_pcie_get_mmio_bar (bdf, &base_addr);
+        if (num == 1) {
+          val_pcie_bar_mem_write (bdf, base_addr + offset, (uint32_t)data);
+        } else if (num == 2) {
+          val_pcie_bar_mem_write (bdf, base_addr + offset, (uint32_t)data);
+          val_pcie_bar_mem_write (bdf, base_addr + offset + 4, (uint32_t )((data & 0xffffffff00000000) >> 32));
+        }
+      }
+  }
+  // val_print(ACS_PRINT_INFO, "\n       IOMMU base: 0x%lx", base_addr);
+  // val_print(ACS_PRINT_INFO, "\n       IOMMU REG value: 0x%x", data);
+
+  return;
 }

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -50,6 +50,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom008_entry(num_hart);
       status |= os_iom011_entry(num_hart);
       status |= os_iom013_entry(num_hart);
+      status |= os_iom014_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -52,6 +52,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom013_entry(num_hart);
       status |= os_iom014_entry(num_hart);
       status |= os_iom017_entry(num_hart);
+      status |= os_iom019_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -47,6 +47,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom003_entry(num_hart);
       status |= os_iom004_entry(num_hart);
       status |= os_iom005_entry(num_hart);
+      status |= os_iom008_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -43,6 +43,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
   if (g_sw_view[G_SW_OS]) {
       val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
       status |= os_iom001_entry(num_hart);
+      status |= os_iom002_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 
@@ -300,4 +301,89 @@ val_iommu_write_iommu_reg(uint32_t index, uint32_t offset, uint32_t num, uint64_
   // val_print(ACS_PRINT_INFO, "\n       IOMMU REG value: 0x%x", data);
 
   return;
+}
+
+/**
+  @brief   This API is to check governing iommu offset
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_hart_create_info_table
+  @param   destiommu_offset  IOMMU offset
+  @return  8-bit data
+**/
+static
+uint8_t
+val_iommu_check_governing_iommu_offset(uint32_t destiommu_offset, uint32_t **iommu_index)
+{
+  uint32_t iommu_num = val_iommu_get_num();
+  uint32_t iommu_offset;
+  uint32_t index;
+
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_IOMMU) {
+      iommu_offset = val_iommu_get_info (index, IOMMU_INFO_IOMMU_OFFSET);
+      if (destiommu_offset == iommu_offset) {
+        **iommu_index = index;
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+  @brief   This API is to check governing iommu node
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_hart_create_info_table
+  @param   bdf  PCIe BDF
+  @param   iommu_index  Pointer of IOMMU index
+  @return  8-bit data
+**/
+uint8_t
+val_iommu_check_governing_iommu(uint32_t bdf, uint32_t *iommu_index)
+{
+  uint32_t index;
+  uint16_t pcie_rc_seg;
+  uint32_t sourceid_base;
+  uint32_t numids;
+  uint32_t destiommu_offset;
+  uint32_t iommu_num = val_iommu_get_num();
+  uint16_t prid;
+  uint16_t segment;
+  uint32_t idmap_index;
+  uint16_t idmap_num;
+
+  if (g_iommu_info_table == NULL)
+    return 0;
+
+  if (iommu_num == 0)
+    return 0;
+
+  // pcie format(seg << 24 bus << 16 dev << 8 func) transfer to prid(PRID format bus << 8 dev << 3 func)
+  segment = (bdf & 0xff000000) >> 24;
+  prid = ((bdf & 0x00ff0000) >> 8) | ((bdf & 0x0000ff00) >> 5) | (bdf & 0x000000ff);
+  val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe PRID: 0x%x", prid);
+  for (index = 0; index < iommu_num; index++) {
+    if (val_iommu_get_info (index, IOMMU_INFO_TYPE) == EFI_ACPI_6_5_RIMT_DEVICE_TYPE_PCIE_ROOT_COMPLEX) {
+      pcie_rc_seg = val_iommu_get_pcierc_platform_info (index, 0, IOMMU_INFO_PCIE_RC_SEG);
+      idmap_num = val_iommu_get_idmap_num (index);
+      if ((pcie_rc_seg != segment) || (idmap_num == 0)) {
+        continue;
+      } else {
+        for (idmap_index = 0; idmap_index < idmap_num; idmap_index++) {
+          sourceid_base = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_SOURCE_ID_BASE);
+          numids = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_NUM_IDS);
+          val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe SOURCE ID BASE: 0x%x", sourceid_base);
+          val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe NUM IDS: 0x%x", numids);
+          if (prid <= (sourceid_base + numids)) {
+            destiommu_offset = val_iommu_get_pcierc_platform_info (index, idmap_index, IOMMU_INFO_DEST_IOMMU_OFFSET);
+            val_print(ACS_PRINT_INFO, "\n       IOMMU PCIe DEST IOMMU OFFSET: 0x%x", destiommu_offset);
+            return val_iommu_check_governing_iommu_offset(destiommu_offset, &iommu_index);
+          } else {
+            continue;
+          }
+        }
+      }
+    }
+  }
+  return 0;
 }

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -54,6 +54,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom017_entry(num_hart);
       status |= os_iom019_entry(num_hart);
       status |= os_iom022_entry(num_hart);
+      status |= os_iom024_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -44,6 +44,8 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
       status |= os_iom001_entry(num_hart);
       status |= os_iom002_entry(num_hart);
+      status |= os_iom003_entry(num_hart);
+      status |= os_iom004_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -51,6 +51,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom011_entry(num_hart);
       status |= os_iom013_entry(num_hart);
       status |= os_iom014_entry(num_hart);
+      status |= os_iom017_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -55,6 +55,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom019_entry(num_hart);
       status |= os_iom022_entry(num_hart);
       status |= os_iom024_entry(num_hart);
+      status |= os_iom026_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_iommu.c
+++ b/val/src/acs_iommu.c
@@ -53,6 +53,7 @@ val_iommu_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_iom014_entry(num_hart);
       status |= os_iom017_entry(num_hart);
       status |= os_iom019_entry(num_hart);
+      status |= os_iom022_entry(num_hart);
   }
   val_print_test_end(status, "IOMMU");
 

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -386,140 +386,140 @@ val_pcie_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
   @param   None
   @return  None
 **/
-// static void
-// val_pcie_print_device_info(void)
-// {
-//   uint32_t bdf;
-//   uint32_t dp_type;
-//   uint32_t tbl_index;
-//   uint32_t ecam_index;
-//   uint64_t ecam_base;
-//   uint32_t ecam_start_bus;
-//   uint32_t ecam_end_bus;
-//   pcie_device_bdf_table *bdf_tbl_ptr;
-//   uint32_t num_rciep = 0, num_rcec = 0;
-//   uint32_t num_iep = 0, num_irp = 0;
-//   uint32_t num_ep = 0, num_rp = 0;
-//   uint32_t num_dp = 0, num_up = 0;
-//   uint32_t num_pcie_pci = 0, num_pci_pcie = 0;
-//   uint32_t bdf_counter;
+static void
+val_pcie_print_device_info(void)
+{
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t tbl_index;
+  uint32_t ecam_index;
+  uint64_t ecam_base;
+  uint32_t ecam_start_bus;
+  uint32_t ecam_end_bus;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  uint32_t num_rciep = 0, num_rcec = 0;
+  uint32_t num_iep = 0, num_irp = 0;
+  uint32_t num_ep = 0, num_rp = 0;
+  uint32_t num_dp = 0, num_up = 0;
+  uint32_t num_pcie_pci = 0, num_pci_pcie = 0;
+  uint32_t bdf_counter;
 
-//   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
-//   tbl_index = 0;
-//   ecam_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  tbl_index = 0;
+  ecam_index = 0;
 
-//   if (bdf_tbl_ptr->num_entries == 0)
-//   {
-//     val_print(ACS_PRINT_ERR, " PCIE_INFO: No entries in BDF Table\n", 0);
-//     return;
-//   }
+  if (bdf_tbl_ptr->num_entries == 0)
+  {
+    val_print(ACS_PRINT_ERR, " PCIE_INFO: No entries in BDF Table\n", 0);
+    return;
+  }
 
-//   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
-//   {
-//       bdf = bdf_tbl_ptr->device[tbl_index].bdf;
-//       dp_type = val_pcie_device_port_type(bdf);
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
 
-//       switch (dp_type)
-//       {
-//         case RCiEP:
-//             num_rciep++;
-//             break;
-//         case RCEC:
-//             num_rcec++;
-//             break;
-//         case EP:
-//             num_ep++;
-//             break;
-//         case RP:
-//             num_rp++;
-//             break;
-//         case iEP_EP:
-//             num_iep++;
-//             break;
-//         case iEP_RP:
-//             num_irp++;
-//             break;
-//         case UP:
-//             num_up++;
-//             break;
-//         case DP:
-//             num_dp++;
-//             break;
-//         case PCI_PCIE:
-//             num_pci_pcie++;
-//             break;
-//         case PCIE_PCI:
-//             num_pcie_pci++;
-//             break;
-//       }
-//   }
+      switch (dp_type)
+      {
+        case RCiEP:
+            num_rciep++;
+            break;
+        case RCEC:
+            num_rcec++;
+            break;
+        case EP:
+            num_ep++;
+            break;
+        case RP:
+            num_rp++;
+            break;
+        case iEP_EP:
+            num_iep++;
+            break;
+        case iEP_RP:
+            num_irp++;
+            break;
+        case UP:
+            num_up++;
+            break;
+        case DP:
+            num_dp++;
+            break;
+        case PCI_PCIE:
+            num_pci_pcie++;
+            break;
+        case PCIE_PCI:
+            num_pcie_pci++;
+            break;
+      }
+  }
 
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of RCiEP           : %4d\n", num_rciep);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of RCEC            : %4d\n", num_rcec);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of EP              : %4d\n", num_ep);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of RP              : %4d\n", num_rp);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of iEP_EP          : %4d\n", num_iep);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of iEP_RP          : %4d\n", num_irp);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of UP of switch    : %4d\n", num_up);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of DP of switch    : %4d\n", num_dp);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of PCI/PCIe Bridge : %4d\n", num_pci_pcie);
-//   val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of PCIe/PCI Bridge : %4d\n", num_pcie_pci);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of RCiEP           : %4d\n", num_rciep);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of RCEC            : %4d\n", num_rcec);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of EP              : %4d\n", num_ep);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of RP              : %4d\n", num_rp);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of iEP_EP          : %4d\n", num_iep);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of iEP_RP          : %4d\n", num_irp);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of UP of switch    : %4d\n", num_up);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of DP of switch    : %4d\n", num_dp);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of PCI/PCIe Bridge : %4d\n", num_pci_pcie);
+  val_print(ACS_PRINT_TEST, " PCIE_INFO: Number of PCIe/PCI Bridge : %4d\n", num_pcie_pci);
 
-//   while (ecam_index < (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
-//   {
-//       ecam_base = val_pcie_get_info(PCIE_INFO_ECAM, ecam_index);
-//       ecam_start_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_START_BUS, ecam_index);
-//       ecam_end_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_END_BUS, ecam_index);
-//       tbl_index = 0;
-//       bdf_counter = 0;
+  while (ecam_index < (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
+  {
+      ecam_base = val_pcie_get_info(PCIE_INFO_ECAM, ecam_index);
+      ecam_start_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_START_BUS, ecam_index);
+      ecam_end_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_END_BUS, ecam_index);
+      tbl_index = 0;
+      bdf_counter = 0;
 
-//       val_print(ACS_PRINT_INFO, "\n  ECAM %d:", ecam_index);
-//       val_print(ACS_PRINT_INFO, "  Base 0x%llx\n", ecam_base);
+      val_print(ACS_PRINT_INFO, "\n  ECAM %d:", ecam_index);
+      val_print(ACS_PRINT_INFO, "  Base 0x%llx\n", ecam_base);
 
-//       while (tbl_index < bdf_tbl_ptr->num_entries)
-//       {
-//           uint32_t seg_num;
-//           uint32_t bus_num;
-//           uint32_t dev_num;
-//           uint32_t func_num;
-//           uint32_t device_id;
-//           uint32_t vendor_id;
-//           uint32_t reg_value;
-//           uint64_t dev_ecam_base;
-//           uint32_t bdf;
+      while (tbl_index < bdf_tbl_ptr->num_entries)
+      {
+          uint32_t seg_num;
+          uint32_t bus_num;
+          uint32_t dev_num;
+          uint32_t func_num;
+          uint32_t device_id;
+          uint32_t vendor_id;
+          uint32_t reg_value;
+          uint64_t dev_ecam_base;
+          uint32_t bdf;
 
-//           bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
-//           seg_num  = PCIE_EXTRACT_BDF_SEG(bdf);
-//           bus_num  = PCIE_EXTRACT_BDF_BUS(bdf);
-//           dev_num  = PCIE_EXTRACT_BDF_DEV(bdf);
-//           func_num = PCIE_EXTRACT_BDF_FUNC(bdf);
+          bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+          seg_num  = PCIE_EXTRACT_BDF_SEG(bdf);
+          bus_num  = PCIE_EXTRACT_BDF_BUS(bdf);
+          dev_num  = PCIE_EXTRACT_BDF_DEV(bdf);
+          func_num = PCIE_EXTRACT_BDF_FUNC(bdf);
 
-//           val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value);
-//           device_id = (reg_value >> TYPE01_DIDR_SHIFT) & TYPE01_DIDR_MASK;
-//           vendor_id = (reg_value >> TYPE01_VIDR_SHIFT) & TYPE01_VIDR_MASK;
+          val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value);
+          device_id = (reg_value >> TYPE01_DIDR_SHIFT) & TYPE01_DIDR_MASK;
+          vendor_id = (reg_value >> TYPE01_VIDR_SHIFT) & TYPE01_VIDR_MASK;
 
-//           dev_ecam_base = val_pcie_get_ecam_base(bdf);
+          dev_ecam_base = val_pcie_get_ecam_base(bdf);
 
-//           if ((ecam_base == dev_ecam_base) && (bus_num >= ecam_start_bus)
-//               && (bus_num <= ecam_end_bus))
-//           {
-//               bdf_counter = 1;
-//               bdf = PCIE_CREATE_BDF(seg_num, bus_num, dev_num, func_num);
-//               val_print(ACS_PRINT_INFO, "  BDF: 0x%x\n", bdf);
-//               val_print(ACS_PRINT_INFO, "  Seg: 0x%x, ", seg_num);
-//               val_print(ACS_PRINT_INFO, "Bus: 0x%02x, ", bus_num);
-//               val_print(ACS_PRINT_INFO, "Dev: 0x%02x, ", dev_num);
-//               val_print(ACS_PRINT_INFO, "Func: 0x%x, ", func_num);
-//               val_print(ACS_PRINT_INFO, "Dev ID: 0x%04x, ", device_id);
-//               val_print(ACS_PRINT_INFO, "Vendor ID: 0x%04x\n", vendor_id);
-//           }
-//       }
-//       if (bdf_counter == 0)
-//           val_print(ACS_PRINT_INFO, "  No BDF devices in ECAM region index %d\n", ecam_index);
+          if ((ecam_base == dev_ecam_base) && (bus_num >= ecam_start_bus)
+              && (bus_num <= ecam_end_bus))
+          {
+              bdf_counter = 1;
+              bdf = PCIE_CREATE_BDF(seg_num, bus_num, dev_num, func_num);
+              val_print(ACS_PRINT_INFO, "  BDF: 0x%x\n", bdf);
+              val_print(ACS_PRINT_INFO, "  Seg: 0x%x, ", seg_num);
+              val_print(ACS_PRINT_INFO, "Bus: 0x%02x, ", bus_num);
+              val_print(ACS_PRINT_INFO, "Dev: 0x%02x, ", dev_num);
+              val_print(ACS_PRINT_INFO, "Func: 0x%x, ", func_num);
+              val_print(ACS_PRINT_INFO, "Dev ID: 0x%04x, ", device_id);
+              val_print(ACS_PRINT_INFO, "Vendor ID: 0x%04x\n", vendor_id);
+          }
+      }
+      if (bdf_counter == 0)
+          val_print(ACS_PRINT_INFO, "  No BDF devices in ECAM region index %d\n", ecam_index);
 
-//       ecam_index++;
-//   }
-// }
+      ecam_index++;
+  }
+}
 
 /**
   @brief   This API will call PAL layer to fill in the PCIe information
@@ -550,20 +550,20 @@ val_pcie_create_info_table(uint64_t *pcie_info_table)
   if (num_ecam == 0)
       return;
 
-  // val_pcie_enumerate();
+  val_pcie_enumerate();
 
   /* Create the list of valid Pcie Device Functions */
-  // if (val_pcie_create_device_bdf_table()) {
-  //     val_print(ACS_PRINT_ERR, "   Create Bdf table failed.\n", 0);
-  //     return;
-  // }
+  if (val_pcie_create_device_bdf_table()) {
+      val_print(ACS_PRINT_ERR, "   Create Bdf table failed.\n", 0);
+      return;
+  }
 
-  // if (pal_pcie_check_device_list()) {
-  //   pcie_bdf_table_list_flag = 1;
-  //   val_print(ACS_PRINT_ERR, "Pcie device list doesn't match with platform pcie device hierarchy\n", 0);
-  // }
+  if (pal_pcie_check_device_list()) {
+    pcie_bdf_table_list_flag = 1;
+    val_print(ACS_PRINT_ERR, "Pcie device list doesn't match with platform pcie device hierarchy\n", 0);
+  }
 
-  // val_pcie_print_device_info();
+  val_pcie_print_device_info();
 }
 
 /**
@@ -572,29 +572,29 @@ val_pcie_create_info_table(uint64_t *pcie_info_table)
   @param  None
   @return 0 if sanity check passes, 1 if sanity check fails
 **/
-// static uint32_t val_pcie_populate_device_rootport(void)
-// {
-//   uint32_t bdf;
-//   uint32_t rp_bdf;
-//   uint32_t tbl_index;
-//   pcie_device_bdf_table *bdf_tbl_ptr;
+static uint32_t val_pcie_populate_device_rootport(void)
+{
+  uint32_t bdf;
+  uint32_t rp_bdf;
+  uint32_t tbl_index;
+  pcie_device_bdf_table *bdf_tbl_ptr;
 
-//   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
-//   tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  tbl_index = 0;
 
-//   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
-//   {
-//       bdf = bdf_tbl_ptr->device[tbl_index].bdf;
-//       val_print(ACS_PRINT_DEBUG, "  Dev bdf 0x%06x", bdf);
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      val_print(ACS_PRINT_DEBUG, "  Dev bdf 0x%06x", bdf);
 
-//       /* Checks if the BDF has RootPort */
-//       val_pcie_get_rootport(bdf, &rp_bdf);
+      /* Checks if the BDF has RootPort */
+      val_pcie_get_rootport(bdf, &rp_bdf);
 
-//       bdf_tbl_ptr->device[tbl_index].rp_bdf = rp_bdf;
-//       val_print(ACS_PRINT_DEBUG, " RP bdf 0x%06x\n", rp_bdf);
-//   }
-//   return 0;
-// }
+      bdf_tbl_ptr->device[tbl_index].rp_bdf = rp_bdf;
+      val_print(ACS_PRINT_DEBUG, " RP bdf 0x%06x\n", rp_bdf);
+  }
+  return 0;
+}
 
 /**
   @brief   This API creates the device bdf table from enumeration
@@ -607,110 +607,110 @@ uint32_t
 val_pcie_create_device_bdf_table()
 {
 
-//   uint32_t num_ecam;
-//   uint32_t seg_num;
-//   uint32_t start_bus;
-//   uint32_t end_bus;
-//   uint32_t bus_index;
-//   uint32_t dev_index;
-//   uint32_t func_index;
-//   uint32_t ecam_index;
-//   uint32_t bdf;
-//   uint32_t reg_value;
-//   uint32_t cid_offset;
-//   uint32_t p_cap;
-//   uint32_t status;
+  uint32_t num_ecam;
+  uint32_t seg_num;
+  uint32_t start_bus;
+  uint32_t end_bus;
+  uint32_t bus_index;
+  uint32_t dev_index;
+  uint32_t func_index;
+  uint32_t ecam_index;
+  uint32_t bdf;
+  uint32_t reg_value;
+  uint32_t cid_offset;
+  uint32_t p_cap;
+  uint32_t status;
 
-//   /* if table is already present, return success */
-//   if (g_pcie_bdf_table)
-//       return PCIE_SUCCESS;
+  /* if table is already present, return success */
+  if (g_pcie_bdf_table)
+      return PCIE_SUCCESS;
 
-//   /* Allocate memory to store BDFs for the valid pcie device functions */
-//   g_pcie_bdf_table = (pcie_device_bdf_table *) pal_aligned_alloc(MEM_ALIGN_8K,
-//                                                                  PCIE_DEVICE_BDF_TABLE_SZ);
-//   if (!g_pcie_bdf_table)
-//   {
-//       val_print(ACS_PRINT_ERR,
-//         "       PCIe BDF table memory allocation failed\n", 0);
-//       return 1;
-//   }
+  /* Allocate memory to store BDFs for the valid pcie device functions */
+  g_pcie_bdf_table = (pcie_device_bdf_table *) pal_aligned_alloc(MEM_ALIGN_8K,
+                                                                 PCIE_DEVICE_BDF_TABLE_SZ);
+  if (!g_pcie_bdf_table)
+  {
+      val_print(ACS_PRINT_ERR,
+        "       PCIe BDF table memory allocation failed\n", 0);
+      return 1;
+  }
 
-//   g_pcie_bdf_table->num_entries = 0;
+  g_pcie_bdf_table->num_entries = 0;
 
-//   num_ecam = (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
-//   if (num_ecam == 0)
-//   {
-//       val_print(ACS_PRINT_ERR, "       No ECAMs discovered\n ", 0);
-//       return 1;
-//   }
+  num_ecam = (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
+  if (num_ecam == 0)
+  {
+      val_print(ACS_PRINT_ERR, "       No ECAMs discovered\n ", 0);
+      return 1;
+  }
 
-//   for (ecam_index = 0; ecam_index < num_ecam; ecam_index++)
-//   {
-//       /* Derive ecam specific information */
-//       seg_num = (uint32_t)val_pcie_get_info(PCIE_INFO_SEGMENT, ecam_index);
-//       start_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_START_BUS, ecam_index);
-//       end_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_END_BUS, ecam_index);
+  for (ecam_index = 0; ecam_index < num_ecam; ecam_index++)
+  {
+      /* Derive ecam specific information */
+      seg_num = (uint32_t)val_pcie_get_info(PCIE_INFO_SEGMENT, ecam_index);
+      start_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_START_BUS, ecam_index);
+      end_bus = (uint32_t)val_pcie_get_info(PCIE_INFO_END_BUS, ecam_index);
 
-//       /* Iterate over all buses, devices and functions in this ecam */
-//       for (bus_index = start_bus; bus_index <= end_bus; bus_index++)
-//       {
-//           for (dev_index = 0; dev_index < PCIE_MAX_DEV; dev_index++)
-//           {
-//               for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++)
-//               {
-//                   /* Form bdf using seg, bus, device, function numbers */
-//                   bdf = PCIE_CREATE_BDF(seg_num, bus_index, dev_index, func_index);
+      /* Iterate over all buses, devices and functions in this ecam */
+      for (bus_index = start_bus; bus_index <= end_bus; bus_index++)
+      {
+          for (dev_index = 0; dev_index < PCIE_MAX_DEV; dev_index++)
+          {
+              for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++)
+              {
+                  /* Form bdf using seg, bus, device, function numbers */
+                  bdf = PCIE_CREATE_BDF(seg_num, bus_index, dev_index, func_index);
 
-//                   /* Probe pcie device Function with this bdf */
-//                   if (val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value) == PCIE_NO_MAPPING)
-//                   {
-//                       /* Return if there is a bdf mapping issue */
-//                       val_print(ACS_PRINT_ERR, "\n       BDF 0x%x mapping issue", bdf);
-//                       return 1;
-//                   }
+                  /* Probe pcie device Function with this bdf */
+                  if (val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value) == PCIE_NO_MAPPING)
+                  {
+                      /* Return if there is a bdf mapping issue */
+                      val_print(ACS_PRINT_ERR, "\n       BDF 0x%x mapping issue", bdf);
+                      return 1;
+                  }
 
-//                   /* Store the Function's BDF if there was a valid response */
-//                   if (reg_value != PCIE_UNKNOWN_RESPONSE)
-//                   {
-//                       /* Skip if the device is a host bridge */
-//                       if (val_pcie_is_host_bridge(bdf))
-//                           continue;
+                  /* Store the Function's BDF if there was a valid response */
+                  if (reg_value != PCIE_UNKNOWN_RESPONSE)
+                  {
+                      /* Skip if the device is a host bridge */
+                      if (val_pcie_is_host_bridge(bdf))
+                          continue;
 
-// #ifndef TARGET_LINUX
-//                       /* Enable memory access and bus master enable for all BDF's
-//                        * For BM systems, these bits are enabled during enumeration in PAL
-//                        * For linux, the driver takes care.
-//                       */
-//                       val_pcie_enable_bme(bdf);
-//                       val_pcie_enable_msa(bdf);
-// #endif
+#ifndef TARGET_LINUX
+                      /* Enable memory access and bus master enable for all BDF's
+                       * For BM systems, these bits are enabled during enumeration in PAL
+                       * For linux, the driver takes care.
+                      */
+                      val_pcie_enable_bme(bdf);
+                      val_pcie_enable_msa(bdf);
+#endif
 
-//                       /* Skip if the device is a PCI legacy device */
-//                       p_cap = val_pcie_find_capability(
-//                         bdf,
-//                         PCIE_CAP,
-//                         CID_PCIECS,
-//                         &cid_offset);
+                      /* Skip if the device is a PCI legacy device */
+                      p_cap = val_pcie_find_capability(
+                        bdf,
+                        PCIE_CAP,
+                        CID_PCIECS,
+                        &cid_offset);
 
-//                       if (p_cap != PCIE_SUCCESS)
-//                           continue;
+                      if (p_cap != PCIE_SUCCESS)
+                          continue;
 
-//                       status = pal_pcie_check_device_valid(bdf);
-//                       if (status)
-//                           continue;
+                      status = pal_pcie_check_device_valid(bdf);
+                      if (status)
+                          continue;
 
-//                       g_pcie_bdf_table->device[g_pcie_bdf_table->num_entries++].bdf = bdf;
-//                   }
-//               }
-//           }
-//       }
-//   }
+                      g_pcie_bdf_table->device[g_pcie_bdf_table->num_entries++].bdf = bdf;
+                  }
+              }
+          }
+      }
+  }
 
-//   /* Sanity Check : Confirm all EP (normal, integrated) have a rootport */
-//   val_pcie_populate_device_rootport();
+  /* Sanity Check : Confirm all EP (normal, integrated) have a rootport */
+  val_pcie_populate_device_rootport();
 
-//   val_print(ACS_PRINT_TEST,
-//     " PCIE_INFO: Number of BDFs found      :    %d\n", g_pcie_bdf_table->num_entries);
+  val_print(ACS_PRINT_TEST,
+    " PCIE_INFO: Number of BDFs found      :    %d\n", g_pcie_bdf_table->num_entries);
 
   return 0;
 }

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -448,6 +448,18 @@ val_pcie_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_p011_entry(num_hart);
       status |= os_p012_entry(num_hart);
       status |= os_p013_entry(num_hart);
+      status |= os_p014_entry(num_hart);
+      status |= os_p015_entry(num_hart);
+      status |= os_p016_entry(num_hart);
+      status |= os_p017_entry(num_hart);
+      status |= os_p018_entry(num_hart);
+      status |= os_p019_entry(num_hart);
+      status |= os_p020_entry(num_hart);
+      status |= os_p021_entry(num_hart);
+      status |= os_p022_entry(num_hart);
+      status |= os_p023_entry(num_hart);
+      status |= os_p024_entry(num_hart);
+      status |= os_p025_entry(num_hart);
   }
 
   // if (g_pcie_bdf_table->num_entries == 0) {

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -444,6 +444,10 @@ val_pcie_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       status |= os_p007_entry(num_hart);
       status |= os_p008_entry(num_hart);
       status |= os_p009_entry(num_hart);
+      status |= os_p010_entry(num_hart);
+      status |= os_p011_entry(num_hart);
+      status |= os_p012_entry(num_hart);
+      status |= os_p013_entry(num_hart);
   }
 
   // if (g_pcie_bdf_table->num_entries == 0) {

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -194,6 +194,79 @@ val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
 }
 
 /**
+  @brief   This API writes 32-bit data to PCIe config space pointed by Bus,
+           Device, Function , register offset, and data width.
+           1. Caller       -  Test Suite
+           2. Prerequisite -  val_pcie_create_info_table
+  @param   bdf    - concatenated Bus(8-bits), device(8-bits) & function(8-bits)
+  @param   offset - Register offset within a device PCIe config space
+  @param   data   - data to be written to the config space
+  @param   width   - data width
+
+  @return  None
+**/
+void
+val_pcie_write_cfg_width(uint32_t bdf, uint32_t offset, void *data, PCI_WIDTH_TYPE width)
+{
+  uint32_t bus      = PCIE_EXTRACT_BDF_BUS(bdf);
+  uint32_t dev      = PCIE_EXTRACT_BDF_DEV(bdf);
+  uint32_t func     = PCIE_EXTRACT_BDF_FUNC(bdf);
+  uint32_t segment  = PCIE_EXTRACT_BDF_SEG(bdf);
+  uint32_t cfg_addr;
+  addr_t   ecam_base = 0;
+  uint32_t i = 0;
+
+
+  if ((bus >= PCIE_MAX_BUS) || (dev >= PCIE_MAX_DEV) || (func >= PCIE_MAX_FUNC)) {
+     val_print(ACS_PRINT_ERR, "\n       Invalid Bus/Dev/Func  %x", bdf);
+     return;
+  }
+
+  if (g_pcie_info_table == NULL) {
+      val_print(ACS_PRINT_ERR, "\n       Write PCIe_CFG: PCIE info table is not created", 0);
+      return;
+  }
+
+  while (i < (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
+  {
+
+      if ((bus >= (uint32_t)val_pcie_get_info(PCIE_INFO_START_BUS, i)) &&
+           (bus <= (uint32_t)val_pcie_get_info(PCIE_INFO_END_BUS, i)) &&
+           (segment == (uint32_t)val_pcie_get_info(PCIE_INFO_SEGMENT, i))) {
+          ecam_base = val_pcie_get_info(PCIE_INFO_ECAM, i);
+          break;
+      }
+      i++;
+  }
+
+  if (ecam_base == 0) {
+      val_print(ACS_PRINT_ERR, "\n       PCIe_CFG_WR ECAM Base is zero %.8x", bdf);
+      return;
+  }
+
+  /* There are 8 functions / device, 32 devices / Bus and each has a 4KB config space */
+  cfg_addr = (bus * PCIE_MAX_DEV * PCIE_MAX_FUNC * 4096) + \
+               (dev * PCIE_MAX_FUNC * 4096) + (func * 4096);
+
+    switch (width) {
+    case PCI_WIDTH_UINT8:
+      pal_mmio_write8(ecam_base + cfg_addr + offset, *(uint8_t *)data);
+      break;
+    case PCI_WIDTH_UINT16:
+      pal_mmio_write16(ecam_base + cfg_addr + offset, *(uint16_t *)data);
+      break;
+    case PCI_WIDTH_UINT32:
+      pal_mmio_write(ecam_base + cfg_addr + offset, *(uint32_t *)data);
+      break;
+    case PCI_WIDTH_UINT64:
+      pal_mmio_write64(ecam_base + cfg_addr + offset, *(uint64_t *)data);
+      break;
+
+  }
+
+}
+
+/**
   @brief   Write 32bit data to PCIe config space pointed by Bus,
            Device, Function and offset using UEFI PciIoProtocol interface
            1. Caller       -  Test Suite
@@ -361,6 +434,26 @@ val_pcie_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
 
       status |= os_p001_entry(num_hart);
+      if (status == ACS_STATUS_FAIL) {
+        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
+        return status;
+      }
+      status |= os_p002_entry(num_hart);
+      if (status == ACS_STATUS_FAIL) {
+        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
+        return status;
+      }
+      status |= os_p003_entry(num_hart);
+      if (status == ACS_STATUS_FAIL) {
+        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
+        return status;
+      }
+      status |= os_p004_entry(num_hart);
+      if (status == ACS_STATUS_FAIL) {
+        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
+        return status;
+      }
+      status |= os_p005_entry(num_hart);
       if (status == ACS_STATUS_FAIL) {
         val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
         return status;

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -29,6 +29,8 @@ uint32_t pcie_bdf_table_list_flag;
 
 uint64_t
 pal_get_mcfg_ptr(void);
+uint64_t
+pal_get_dsdt_ptr(void);
 /**
   @brief   This API reads 32-bit data from PCIe config space pointed by Bus,
            Device, Function and register offset.
@@ -434,30 +436,14 @@ val_pcie_execute_tests(uint32_t num_hart, uint32_t *g_sw_view)
       val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
 
       status |= os_p001_entry(num_hart);
-      if (status == ACS_STATUS_FAIL) {
-        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
-        return status;
-      }
       status |= os_p002_entry(num_hart);
-      if (status == ACS_STATUS_FAIL) {
-        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
-        return status;
-      }
       status |= os_p003_entry(num_hart);
-      if (status == ACS_STATUS_FAIL) {
-        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
-        return status;
-      }
       status |= os_p004_entry(num_hart);
-      if (status == ACS_STATUS_FAIL) {
-        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
-        return status;
-      }
       status |= os_p005_entry(num_hart);
-      if (status == ACS_STATUS_FAIL) {
-        val_print(ACS_PRINT_WARN, "\n      *** Skipping remaining PCIE tests ***\n", 0);
-        return status;
-      }
+      status |= os_p006_entry(num_hart);
+      status |= os_p007_entry(num_hart);
+      status |= os_p008_entry(num_hart);
+      status |= os_p009_entry(num_hart);
   }
 
   // if (g_pcie_bdf_table->num_entries == 0) {
@@ -925,6 +911,8 @@ val_pcie_get_info(PCIE_INFO_e type, uint32_t index)
           return g_pcie_info_table->block[index].end_bus_num;
       case PCIE_INFO_SEGMENT:
           return g_pcie_info_table->block[index].segment_num;
+      case PCIE_INFO_DSDT_PTR:
+          return pal_get_dsdt_ptr();
       default:
           val_print(ACS_PRINT_ERR, "This PCIE info option not supported %d\n", type);
           break;


### PR DESCRIPTION
**1. Add IOMMU test cases**

- Update ME_IOM_010_010
- Add ME_IOM_020_010
- Add ME_IOM_030_010
- Add ME_IOM_040_010
- Add ME_IOM_050_010
- Add ME_IOM_080_010
- Add ME_IOM_110_010
- Add ME_IOM_130_010
- Add ME_IOM_140_010
- Add ME_IOM_170_010
- Add ME_IOM_190_010
- Add ME_IOM_220_010
- Add ME_IOM_240_010
- Add ME_IOM_260_010

**2. Add PCIe test cases**
(1) Add ECAM test cases
- Add MF_ECM_010_010
- Add MF_ECM_030_010
- Add MF_ECM_040_010
- Add MF_ECM_060_010
- Add MF_ECM_070_010
- Add MF_ECM_090_010
- Add MF_ECM_100_010

(2) Add MMS test cases
- Add ME_MMS_010_010
- Add ME_MMS_020_010
- Add MF_MMS_040_010
- Add MF_MMS_050_010
- Add ME_MMS_080_010

(3) Add ACS test cases
- Add ME_ACS_010_010
- Add ME_ACS_020_010

(4) Add MSI test cases
- Add ME_MSI_010_010

(5) Add PTM test cases
- Add OE_PTM_010_010

(6) Add AER test cases
- Add ME_AER_010_010
- Add ME_AER_020_010
- Add ME_AER_030_010
- Add ME_AER_040_010
- Add ME_AER_050_010
- Add ME_AER_060_010
- Add ME_AER_070_010

(7) Add VSR test cases
- Add MF_VSR_010_010

(8) Add SID test cases
- Add MF_SID_020_010
- Add ME_SID_040_010
- Add ME_SID_050_010
- Add ME_SID_070_010
- Add ME_SID_090_010
- Add ME_SID_100_010